### PR TITLE
look for mpi header in system path instead of file path

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -28,7 +28,7 @@ if env["DEBUG"]:
 env.Append(LIBS = ["mprio", "mpi", "nss3", "nspr4"], \
   LIBPATH = ['#build/prio', "#build/mpi"],
   CFLAGS = [ "-Wall", "-Werror", "-Wextra", "-O3", "-std=c99", 
-    "-I/usr/include/nspr", "-DDO_PR_CLEANUP"])
+    "-I/usr/include/nspr", "-Impi", "-DDO_PR_CLEANUP"])
 
 env.Append(CPPPATH = ["#include", "#."])
 Export('env')

--- a/prio/client.c
+++ b/prio/client.c
@@ -9,8 +9,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <mprio.h>
+#include <mpi.h>
 
-#include "mpi/mpi.h"
 #include "client.h"
 #include "config.h"
 #include "encrypt.h"

--- a/prio/client.c
+++ b/prio/client.c
@@ -5,11 +5,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <mpi.h>
+#include <mprio.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <mprio.h>
-#include <mpi.h>
 
 #include "client.h"
 #include "config.h"

--- a/prio/config.c
+++ b/prio/config.c
@@ -6,8 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
-#include <stdlib.h>
 #include <mprio.h>
+#include <stdlib.h>
 
 #include "config.h"
 #include "params.h"

--- a/prio/config.h
+++ b/prio/config.h
@@ -9,7 +9,8 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-#include "mpi/mpi.h"
+#include <mpi.h>
+
 #include "mparray.h"
 
 struct prio_config {

--- a/prio/mparray.h
+++ b/prio/mparray.h
@@ -9,8 +9,8 @@
 #ifndef __MPARRAY_H__
 #define __MPARRAY_H__
 
-#include <mprio.h>
 #include <mpi.h>
+#include <mprio.h>
 
 struct mparray {
   int len;

--- a/prio/mparray.h
+++ b/prio/mparray.h
@@ -10,7 +10,7 @@
 #define __MPARRAY_H__
 
 #include <mprio.h>
-#include "mpi/mpi.h"
+#include <mpi.h>
 
 struct mparray {
   int len;

--- a/prio/poly.h
+++ b/prio/poly.h
@@ -11,8 +11,8 @@
 
 #include <mprio.h>
 #include <stdbool.h>
+#include <mpi.h>
 
-#include "mpi/mpi.h"
 #include "mparray.h"
 
 /*

--- a/prio/poly.h
+++ b/prio/poly.h
@@ -9,9 +9,9 @@
 #ifndef _FFT__H
 #define _FFT__H
 
+#include <mpi.h>
 #include <mprio.h>
 #include <stdbool.h>
-#include <mpi.h>
 
 #include "mparray.h"
 

--- a/prio/prg.h
+++ b/prio/prg.h
@@ -9,9 +9,9 @@
 #ifndef __PRG_H__
 #define __PRG_H__
 
+#include <mpi.h>
 #include <nss/blapit.h>
 #include <stdlib.h>
-#include <mpi.h>
 
 #include "config.h"
 

--- a/prio/prg.h
+++ b/prio/prg.h
@@ -11,8 +11,8 @@
 
 #include <nss/blapit.h>
 #include <stdlib.h>
+#include <mpi.h>
 
-#include "mpi/mpi.h"
 #include "config.h"
 
 typedef struct prg *PRG;

--- a/prio/rand.c
+++ b/prio/rand.c
@@ -7,10 +7,10 @@
  */
 
 #include <limits.h>
+#include <mprio.h>
 #include <nss/nss.h>
 #include <nss/pk11pub.h>
 #include <nspr/prinit.h>
-#include <mprio.h>
 
 #include "debug.h"
 #include "rand.h"

--- a/prio/rand.h
+++ b/prio/rand.h
@@ -9,9 +9,9 @@
 #ifndef __RAND_H__
 #define __RAND_H__
 
+#include <mpi.h>
 #include <nss/seccomon.h>
 #include <stdlib.h>
-#include <mpi.h>
 
 /*
  * Typedef for function pointer. A function pointer of type RandBytesFunc

--- a/prio/rand.h
+++ b/prio/rand.h
@@ -11,7 +11,7 @@
 
 #include <nss/seccomon.h>
 #include <stdlib.h>
-#include "mpi/mpi.h"
+#include <mpi.h>
 
 /*
  * Typedef for function pointer. A function pointer of type RandBytesFunc

--- a/prio/serial.c
+++ b/prio/serial.c
@@ -8,6 +8,7 @@
 
 #include <mprio.h>
 #include <msgpack.h>
+
 #include "client.h"
 #include "serial.h"
 #include "server.h"

--- a/prio/server.c
+++ b/prio/server.c
@@ -9,8 +9,8 @@
 #include <mprio.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <mpi.h>
 
-#include "mpi/mpi.h"
 #include "client.h"
 #include "prg.h"
 #include "poly.h"

--- a/prio/server.c
+++ b/prio/server.c
@@ -6,10 +6,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
+#include <mpi.h>
 #include <mprio.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <mpi.h>
 
 #include "client.h"
 #include "prg.h"

--- a/prio/share.h
+++ b/prio/share.h
@@ -10,7 +10,8 @@
 #ifndef __SHARE_H__
 #define __SHARE_H__
 
-#include "mpi/mpi.h"
+#include <mpi.h>
+
 #include "config.h"
 
 struct beaver_triple {

--- a/prio/util.h
+++ b/prio/util.h
@@ -9,8 +9,8 @@
 #ifndef __UTIL_H__
 #define __UTIL_H__
 
-#include <mprio.h>
 #include <mpi.h>
+#include <mprio.h>
 
 // Minimum of two values
 #define MIN(a, b) ((a) < (b) ? (a) : (b))

--- a/prio/util.h
+++ b/prio/util.h
@@ -10,7 +10,7 @@
 #define __UTIL_H__
 
 #include <mprio.h>
-#include "mpi/mpi.h"
+#include <mpi.h>
 
 // Minimum of two values
 #define MIN(a, b) ((a) < (b) ? (a) : (b))

--- a/ptest/client_test.c
+++ b/ptest/client_test.c
@@ -7,6 +7,7 @@
  */
 
 #include <mprio.h>
+
 #include "prio/client.h"
 #include "prio/server.h"
 #include "prio/util.h"

--- a/ptest/encrypt_test.c
+++ b/ptest/encrypt_test.c
@@ -6,15 +6,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
-#include "mutest.h"
-
+#include <nspr.h>
 #include <nss/nss.h>
 #include <nss/secoidt.h>
-#include <nspr.h>
 #include <nss/keyhi.h>
 #include <nss/pk11pub.h>
 #include <nss/cert.h>
 
+#include "mutest.h"
 #include "prio/encrypt.h"
 #include "prio/rand.h"
 #include "prio/util.h"

--- a/ptest/fft_test.c
+++ b/ptest/fft_test.c
@@ -6,15 +6,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
-#include <stdio.h>
-#include <mprio.h>
 #include <mpi.h>
+#include <mprio.h>
+#include <stdio.h>
 
+#include "mutest.h"
 #include "prio/config.h"
 #include "prio/mparray.h"
 #include "prio/poly.h"
 #include "prio/util.h"
-#include "mutest.h"
 
 void 
 mu_test__fft_one (void)

--- a/ptest/fft_test.c
+++ b/ptest/fft_test.c
@@ -8,8 +8,8 @@
 
 #include <stdio.h>
 #include <mprio.h>
+#include <mpi.h>
 
-#include "mpi/mpi.h"
 #include "prio/config.h"
 #include "prio/mparray.h"
 #include "prio/poly.h"

--- a/ptest/mpi_test.c
+++ b/ptest/mpi_test.c
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
-#include "mpi/mpi.h"
+#include <mpi.h>
+
 #include "mutest.h"
 
 

--- a/ptest/mutest.c
+++ b/ptest/mutest.c
@@ -13,10 +13,11 @@
  * Please, read the README file for more details.
  */
 
-#include "mutest.h" /* MU_* constants, mu_print() */
 #include <mprio.h>
 #include <stdio.h> /* printf(), fprintf() */
 #include <string.h> /* strncmp() */
+
+#include "mutest.h" /* MU_* constants, mu_print() */
 
 /*
  * note that all global variables are public because they need to be accessed

--- a/ptest/prg_test.c
+++ b/ptest/prg_test.c
@@ -7,8 +7,8 @@
  */
 
 
+#include <mpi.h>
 
-#include "mpi/mpi.h"
 #include "prio/prg.h"
 #include "prio/util.h"
 #include "mutest.h"

--- a/ptest/prg_test.c
+++ b/ptest/prg_test.c
@@ -6,12 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
-
 #include <mpi.h>
 
+#include "mutest.h"
 #include "prio/prg.h"
 #include "prio/util.h"
-#include "mutest.h"
 
 void
 mu_test__prg_simple (void) 

--- a/ptest/rand_test.c
+++ b/ptest/rand_test.c
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
-#include "mpi/mpi.h"
+#include <mpi.h>
+
 #include "prio/rand.h"
 #include "prio/util.h"
 #include "mutest.h"

--- a/ptest/rand_test.c
+++ b/ptest/rand_test.c
@@ -8,9 +8,9 @@
 
 #include <mpi.h>
 
+#include "mutest.h"
 #include "prio/rand.h"
 #include "prio/util.h"
-#include "mutest.h"
 
 void 
 mu_test__util_msb_mast (void)

--- a/ptest/serial_test.c
+++ b/ptest/serial_test.c
@@ -9,8 +9,8 @@
 #include <mprio.h>
 #include <msgpack.h>
 #include <string.h>
-#include "mutest.h"
 
+#include "mutest.h"
 #include "prio/client.h"
 #include "prio/config.h"
 #include "prio/serial.h"

--- a/ptest/server_test.c
+++ b/ptest/server_test.c
@@ -6,10 +6,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
-#include <mprio.h>
 #include <mpi.h>
-#include "mutest.h"
+#include <mprio.h>
 
+#include "mutest.h"
 #include "prio/client.h"
 #include "prio/server.h"
 #include "prio/server.c"

--- a/ptest/server_test.c
+++ b/ptest/server_test.c
@@ -7,9 +7,9 @@
  */
 
 #include <mprio.h>
+#include <mpi.h>
 #include "mutest.h"
 
-#include "mpi/mpi.h"
 #include "prio/client.h"
 #include "prio/server.h"
 #include "prio/server.c"

--- a/ptest/share_test.c
+++ b/ptest/share_test.c
@@ -7,8 +7,8 @@
  */
 
 #include <mprio.h>
+#include <mpi.h>
 
-#include "mpi/mpi.h"
 #include "prio/client.h"
 #include "prio/config.h"
 #include "prio/mparray.h"

--- a/ptest/share_test.c
+++ b/ptest/share_test.c
@@ -6,8 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
  */
 
-#include <mprio.h>
 #include <mpi.h>
+#include <mprio.h>
 
 #include "prio/client.h"
 #include "prio/config.h"


### PR DESCRIPTION
Good thing @franziskuskiefer asked me to remove `mpi/` dir when we import - we were still trying to build against the header in libprio, not the one in m-c!

I've tested that this builds fine in mozilla-central if I add the NSS `mpi/` dir to the include path, and libprio also builds fine for me with Scons.
