### PR TITLE
free PK11 slot as this appears to be leaking NSS resources at shutdown

### DIFF
--- a/prio/encrypt.c
+++ b/prio/encrypt.c
@@ -186,6 +186,7 @@ Keypair_new (PrivateKey *pvtkey, PublicKey *pubkey)
   P_CHECKA (slot = PK11_GetInternalSlot ());
   P_CHECKA (*pvtkey = PK11_GenerateKeyPair(slot, CKM_EC_KEY_PAIR_GEN, &ecp, 
       (SECKEYPublicKey **)pubkey, PR_FALSE, PR_FALSE, NULL));
+  PK11_FreeSlot (slot);
 
 cleanup:
   if (ecp.data)


### PR DESCRIPTION
So I am still seeing an NSS assert at shutdown when using Prio in debug builds, I debugged it down to here:
https://searchfox.org/mozilla-central/rev/f2ac80ab7dbde5400a3400d463e07331194dec94/security/nss/lib/pk11wrap/pk11util.c#91

It looks like what's happening is `PK11_GetInternalSlot` is called without a corresponding `PK11_FreeSlot`, which is what this PR does. (`PK11_FreeSlot` returns void which is why there is no error check)

I'm testing on macOS and don't see the assert in my local debug build with this patch, and it also passes the libprio browser-test.