### PR TITLE
issue #25 - use clang as the compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: c
 
-# msgpack is super old in currently-supported Ubuntu repos
-sudo: true
 before_install:
+  - source ~/virtualenv/python2.7/bin/activate
+  - pip install --upgrade pip setuptools wheel SCons==3.0.1
   - wget https://github.com/msgpack/msgpack-c/releases/download/cpp-3.1.0/msgpack-3.1.0.tar.gz
   - tar xf msgpack-3.1.0.tar.gz
   - cd msgpack-3.1.0 && cmake . && make && sudo make install && cd ../

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ the dominant costs of the system are:
 
 You must first install 
 [NSS/NSPR](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS), 
-[scons](http://scons.org/), and 
+[SCons](http://scons.org/) version 3.0.1 (or newer?), and
 [msgpack-c](https://github.com/msgpack/msgpack-c) version 2.1.5 (or newer?).
 On Ubuntu, you can instal NSS and scons with:
 

--- a/SConstruct
+++ b/SConstruct
@@ -12,6 +12,9 @@ opts.AddVariables(
 
 env = Environment(options = opts,
                   ENV = os.environ)
+
+env.Tool('clang')
+
 if "CFLAGS" in os.environ:
   env.Append(CFLAGS = SCons.Util.CLVar(os.getenv("CFLAGS")))
 if "CPPFLAGS" in os.environ:


### PR DESCRIPTION
I'd suggest using Clang as the supported compiler - I know the big open source projects are moving to it on all platforms, and there are a lot of supported static analysis tools.