### PR TITLE
per bug 1465251, switch to sync version of PrioEncoder.encode()

### DIFF
--- a/browser-test/encode-once.js
+++ b/browser-test/encode-once.js
@@ -13,25 +13,22 @@ let [publicKeyA, publicKeyB, batchID, param1, param2, param3] = arguments;
 Services.prefs.setStringPref('prio.publicKeyA', publicKeyA);
 Services.prefs.setStringPref('prio.publicKeyB', publicKeyB);
 
-async function test() {
-  let params =  {
-    'browserIsUserDefault': Number(param1),
-    'newTabPageEnabled': Number(param2),
-    'userChromeCssLoaded': Number(param3)
-  };
+let params =  {
+  'browserIsUserDefault': Number(param1),
+  'newTabPageEnabled': Number(param2),
+  'userChromeCssLoaded': Number(param3)
+};
 
-  try {
-    let result = await PrioEncoder.encode(batchID, params);
+try {
+  let result = PrioEncoder.encode(batchID, params);
 
-    const toHexString = bytes =>
-      bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0') + ',', '');
+  const toHexString = bytes =>
+    bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0') + ',', '');
 
-    console.log(toHexString(result.a) + '$' + toHexString(result.b));
-    console.log('');
-  } catch(e) {
-    console.log('Failure.', e);
-    console.log(v);
-  }
+  console.log(toHexString(result.a) + '$' + toHexString(result.b));
+  console.log('');
+} catch(e) {
+  console.log('Failure.', e);
+  console.log(v);
 }
 
-test().then();


### PR DESCRIPTION
Another silly late-breaking API change - turns out the code using this is all synchronous so making a Promise-based API is counter-productive. Pretty trivial change, but it avoids some terrible JS code in the consumer this way.