### PR TITLE
Add CCFLAGS to compiler options

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -15,20 +15,17 @@ env = Environment(options = opts,
 
 env.Tool('clang')
 
-if "CFLAGS" in os.environ:
-  env.Append(CFLAGS = SCons.Util.CLVar(os.getenv("CFLAGS")))
-if "CPPFLAGS" in os.environ:
-  env.Append(CPPFLAGS = SCons.Util.CLVar(os.getenv("CPPFLAGS")))
-if "CXXFLAGS" in os.environ:
-  env.Append(CXXFLAGS = SCons.Util.CLVar(os.getenv("CXXFLAGS")))
-if "LDFLAGS" in os.environ:
-  env.Append(LINKFLAGS = SCons.Util.CLVar(os.getenv("LDFLAGS")))
+# Add extra compiler flags from the environment
+for flag in ["CCFLAGS", "CFLAGS", "CPPFLAGS", "CXXFLAGS", "LDFLAGS"]:
+  if flag in os.environ:
+    env.Append(**{flag: SCons.Util.CLVar(os.getenv(flag))})
 
 if env["DEBUG"]: 
-    print "DEBUG MODE!"
-    env.Append(CPPFLAGS = [ "-g", "-DDEBUG"])
+    print("DEBUG MODE!")
+    env.Append(CCFLAGS = ["-g", "-DDEBUG"])
 
-env.Append(LIBS = ["mprio", "mpi", "nss3", "nspr4"], \
+env.Append(
+  LIBS = ["mprio", "mpi", "nss3", "nspr4"],
   LIBPATH = ['#build/prio', "#build/mpi"],
   CFLAGS = [ "-Wall", "-Werror", "-Wextra", "-O3", "-std=c99", 
     "-I/usr/include/nspr", "-Impi", "-DDO_PR_CLEANUP"])


### PR DESCRIPTION
I want to compile libprio with position independent code (`-fPIC`) to wrap it in a Python library. Setting `CFLAGS='-fPIC' scons` unfortunately doesn't work because the flags are reset in MPI.

https://github.com/mozilla/libprio/blob/02beee180ea3e9b88a45059fd878760c48c187ba/mpi/SConscript#L6

This PR adds a compiler flag that isn't overloaded. According to the [SCons documentation](https://www.scons.org/doc/HTML/scons-user.html#cv-CCFLAGS) and [this user guide](http://pages.cs.wisc.edu/~driscoll/software/scons/variables.html), `CCFLAGS` is a commonly used variable that gets passed to both the C and C++ compiler.
