### PR TITLE
change readme and SConstruct to specify linkflags not ldflags

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For macOS using Homebrew:
 
     $ brew install nss nspr scons msgpack
 
-    $ export LDFLAGS="-L/usr/local/opt/nss/lib"
+    $ export LINKFLAGS="-L/usr/local/opt/nss/lib"
     $ export CPPFLAGS="-I/usr/local/opt/nss/include -I/usr/local/opt/nspr/include/nspr"
 
 To compile the code, run:

--- a/SConstruct
+++ b/SConstruct
@@ -16,7 +16,7 @@ env = Environment(options = opts,
 env.Tool('clang')
 
 # Add extra compiler flags from the environment
-for flag in ["CCFLAGS", "CFLAGS", "CPPFLAGS", "CXXFLAGS", "LDFLAGS"]:
+for flag in ["CCFLAGS", "CFLAGS", "CPPFLAGS", "CXXFLAGS", "LINKFLAGS"]:
   if flag in os.environ:
     env.Append(**{flag: SCons.Util.CLVar(os.getenv(flag))})
 


### PR DESCRIPTION
PR #34 changes the way compiler flags are read from the environment, and
SCons seems to want `LINKFLAGS` set in the enviroment instead of
`LDFLAGS` - this was being mapped before.

It's probably not worth re-mapping this, instead just change it so what is
specified in the README still works for platforms that need to install
NSS in a weird place (like macOS and Windows) :)