### PR TITLE
Workaround for NSS AES-NI bug on Windows

### DIFF
--- a/prio/client.c
+++ b/prio/client.c
@@ -211,7 +211,7 @@ PrioPacketClient_set_data(const_PrioConfig cfg, const bool* data_in,
     return SECFailure;
 
   P_CHECKC(PrioPRGSeed_randomize(&pB->shares.B.seed));
-  P_CHECKA(prgB = PRG_new(pB->shares.B.seed));
+  P_CHECKA(prgB = PRG_new(pB->shares.B.seed, PRIO_DEFAULT_PRG));
 
   P_CHECKC(BeaverTriple_set_rand(cfg, pA->triple, pB->triple));
   P_CHECKA(client_data = MPArray_new_bool(data_len, data_in));

--- a/prio/prg.c
+++ b/prio/prg.c
@@ -9,18 +9,33 @@
 #include <mprio.h>
 #include <nss/blapit.h>
 #include <nss/pk11pub.h>
-#include <string.h>
 
 #include "prg.h"
 #include "rand.h"
 #include "share.h"
 #include "util.h"
 
+// Size (in bytes) of buffer to use for `PRG_BUFFERING` mode.
+// Should be a multiple of `AES_BLOCK_SIZE`.
+static const size_t PRG_BUFFER_SIZE = AES_BLOCK_SIZE * 128;
+// Number of bits use for AES-CTR counter.
+static const int AES_COUNTER_BITS = 128;
+// Use AES-CTR mode for PRG.
+static const CK_MECHANISM_TYPE PRG_CIPHER = CKM_AES_CTR;
+
 struct prg
 {
+  PRGMethod meth;
   PK11SlotInfo* slot;
   PK11SymKey* key;
+  CK_AES_CTR_PARAMS param;
+
+  // For method `PRG_SIMPLE`.
   PK11Context* ctx;
+
+  // For method `PRG_BUFFERING`.
+  unsigned char* buf;
+  size_t bytes_used;
 };
 
 SECStatus
@@ -29,19 +44,28 @@ PrioPRGSeed_randomize(PrioPRGSeed* key)
   return rand_bytes((unsigned char*)key, PRG_SEED_LENGTH);
 }
 
+static PK11Context*
+create_context(PRG prg)
+{
+  SECItem paramItem = { siBuffer, (void*)&prg->param,
+                        sizeof(CK_AES_CTR_PARAMS) };
+  return PK11_CreateContextBySymKey(PRG_CIPHER, CKA_ENCRYPT, prg->key,
+                                    &paramItem);
+}
+
 PRG
-PRG_new(const PrioPRGSeed key_in)
+PRG_new(const PrioPRGSeed key_in, PRGMethod meth)
 {
   PRG prg = malloc(sizeof(struct prg));
   if (!prg)
     return NULL;
+  prg->meth = meth;
   prg->slot = NULL;
   prg->key = NULL;
   prg->ctx = NULL;
+  prg->buf = NULL;
 
   SECStatus rv = SECSuccess;
-  const CK_MECHANISM_TYPE cipher = CKM_AES_CTR;
-
   P_CHECKA(prg->slot = PK11_GetInternalSlot());
 
   // Create a mutable copy of the key.
@@ -52,14 +76,30 @@ PRG_new(const PrioPRGSeed key_in)
 
   // The IV can be all zeros since we only encrypt once with
   // each AES key.
-  CK_AES_CTR_PARAMS param = { 128, {} };
-  SECItem paramItem = { siBuffer, (void*)&param, sizeof(CK_AES_CTR_PARAMS) };
+  prg->param.ulCounterBits = AES_COUNTER_BITS;
+  memset(prg->param.cb, 0, AES_BLOCK_SIZE);
 
-  P_CHECKA(prg->key = PK11_ImportSymKey(prg->slot, cipher, PK11_OriginUnwrap,
-                                        CKA_ENCRYPT, &keyItem, NULL));
+  P_CHECKA(prg->key =
+             PK11_ImportSymKey(prg->slot, PRG_CIPHER, PK11_OriginUnwrap,
+                               CKA_ENCRYPT, &keyItem, NULL));
 
-  P_CHECKA(prg->ctx = PK11_CreateContextBySymKey(cipher, CKA_ENCRYPT, prg->key,
-                                                 &paramItem));
+  switch (prg->meth) {
+    case PRG_SIMPLE:
+      P_CHECKA(prg->ctx = create_context(prg));
+      break;
+
+    case PRG_BUFFERING:
+      // Set this to the buffer length to make sure that we
+      // fill the buffer before giving out any output.
+      prg->bytes_used = PRG_BUFFER_SIZE;
+      P_CHECKA(prg->buf = calloc(PRG_BUFFER_SIZE, sizeof(unsigned char)));
+      break;
+
+    default:
+      // Should never get here
+      P_CHECKC(SECFailure);
+      break;
+  }
 
 cleanup:
   if (rv != SECSuccess) {
@@ -82,33 +122,136 @@ PRG_clear(PRG prg)
     PK11_FreeSlot(prg->slot);
   if (prg->ctx)
     PK11_DestroyContext(prg->ctx, PR_TRUE);
+  if (prg->buf)
+    free(prg->buf);
 
   free(prg);
 }
 
 static SECStatus
-PRG_get_bytes_internal(void* prg_vp, unsigned char* bytes, size_t len)
+get_bytes_internal_simple(PK11Context* ctx, unsigned char* bytes, size_t len)
 {
-  PRG prg = (PRG)prg_vp;
-
-  unsigned char in[len];
-  memset(in, 0, len);
+  SECStatus rv = SECSuccess;
+  unsigned char* in = NULL;
+  P_CHECKA(in = calloc(len, sizeof(unsigned char)));
 
   int outlen;
-  SECStatus rv = PK11_CipherOp(prg->ctx, bytes, &outlen, len, in, len);
-  return (rv != SECSuccess || (size_t)outlen != len) ? SECFailure : SECSuccess;
+  P_CHECKC(PK11_CipherOp(ctx, bytes, &outlen, len, in, len));
+  P_CHECKCB(((size_t)outlen) == len);
+
+cleanup:
+  if (in) {
+    free(in);
+  }
+
+  return rv;
+}
+
+// Code to increment the AES-CTR counter.
+// Lifted from NSS:  security/nss/lib/freebl/ctr.c
+static void
+get_next_counter(unsigned char* counter, unsigned int counterBits,
+                 unsigned int blocksize)
+{
+  unsigned char* counterPtr = counter + blocksize - 1;
+  unsigned char mask, count;
+
+  PORT_Assert(counterBits <= blocksize * PR_BITS_PER_BYTE);
+  while (counterBits >= PR_BITS_PER_BYTE) {
+    if (++(*(counterPtr--))) {
+      return;
+    }
+    counterBits -= PR_BITS_PER_BYTE;
+  }
+  if (counterBits == 0) {
+    return;
+  }
+  // increment the final partial byte
+  mask = (1 << counterBits) - 1;
+  count = ++(*counterPtr) & mask;
+  *counterPtr = ((*counterPtr) & ~mask) | count;
+  return;
+}
+
+static SECStatus
+refill_buffer(PRG prg)
+{
+  if (!(prg && prg->meth == PRG_BUFFERING && prg->ctx == NULL &&
+        prg->bytes_used == PRG_BUFFER_SIZE)) {
+    return SECFailure;
+  }
+
+  PK11Context* ctx = NULL;
+  const size_t blocks_in_buf = (PRG_BUFFER_SIZE / AES_BLOCK_SIZE);
+
+  SECStatus rv = SECSuccess;
+  P_CHECKA(ctx = create_context(prg));
+  P_CHECKC(get_bytes_internal_simple(ctx, prg->buf, PRG_BUFFER_SIZE));
+  prg->bytes_used = 0;
+
+  // Increment counter
+  for (size_t i = 0; i < blocks_in_buf; i++) {
+    // TODO: If we are going to keep this for the long run, we should
+    // increment the counter in a more efficient way.
+    get_next_counter(prg->param.cb, prg->param.ulCounterBits, AES_BLOCK_SIZE);
+  }
+
+cleanup:
+  if (ctx) {
+    PK11_DestroyContext(ctx, PR_TRUE);
+  }
+
+  return rv;
+}
+
+static SECStatus
+get_bytes_internal_buffering(PRG prg, unsigned char* bytes, size_t len)
+{
+  SECStatus rv = SECSuccess;
+  unsigned char* outp = bytes;
+  size_t needed = len;
+
+  do {
+    const size_t in_buf = PRG_BUFFER_SIZE - prg->bytes_used;
+    const size_t to_copy = MIN(needed, in_buf);
+    memcpy(outp, prg->buf + prg->bytes_used, to_copy);
+    outp += to_copy;
+    needed -= to_copy;
+    prg->bytes_used += to_copy;
+
+    if (prg->bytes_used == PRG_BUFFER_SIZE) {
+      P_CHECKC(refill_buffer(prg));
+    }
+  } while (needed);
+
+cleanup:
+  return rv;
+}
+
+static SECStatus
+PRG_get_bytes_internal(void* prg_vp, unsigned char* bytes, size_t len)
+{
+  PRG prg = prg_vp;
+  switch (prg->meth) {
+    case PRG_SIMPLE:
+      return get_bytes_internal_simple(prg->ctx, bytes, len);
+    case PRG_BUFFERING:
+      return get_bytes_internal_buffering(prg, bytes, len);
+    default:
+      return SECFailure;
+  }
 }
 
 SECStatus
 PRG_get_bytes(PRG prg, unsigned char* bytes, size_t len)
 {
-  return PRG_get_bytes_internal((void*)prg, bytes, len);
+  return PRG_get_bytes_internal(prg, bytes, len);
 }
 
 SECStatus
 PRG_get_int(PRG prg, mp_int* out, const mp_int* max)
 {
-  return rand_int_rng(out, max, &PRG_get_bytes_internal, (void*)prg);
+  return rand_int_rng(out, max, &PRG_get_bytes_internal, prg);
 }
 
 SECStatus

--- a/prio/rand.c
+++ b/prio/rand.c
@@ -112,7 +112,7 @@ rand_int_rng(mp_int* out, const mp_int* max, RandBytesFunc rng_func,
     MP_CHECK(mp_read_unsigned_octets(out, buf, nbytes));
   } while (mp_cmp(out, max) != -1);
 
-  return 0;
+  return SECSuccess;
 }
 
 void

--- a/prio/server.c
+++ b/prio/server.c
@@ -33,7 +33,7 @@ PrioServer_new(const_PrioConfig cfg, PrioServerId server_idx,
   s->prg = NULL;
 
   P_CHECKA(s->data_shares = MPArray_new(s->cfg->num_data_fields));
-  P_CHECKA(s->prg = PRG_new(seed));
+  P_CHECKA(s->prg = PRG_new(seed, PRIO_DEFAULT_PRG));
 
 cleanup:
   if (rv != SECSuccess) {
@@ -297,7 +297,7 @@ PrioVerifier_set_data(PrioVerifier v, unsigned char* data,
   }
 
   if (v->s->idx == PRIO_SERVER_B) {
-    P_CHECKA(prgB = PRG_new(v->clientp->shares.B.seed));
+    P_CHECKA(prgB = PRG_new(v->clientp->shares.B.seed, PRIO_DEFAULT_PRG));
     P_CHECKC(PRG_get_array(prgB, v->data_sharesB, &v->s->cfg->modulus));
     P_CHECKC(PRG_get_array(prgB, v->h_pointsB, &v->s->cfg->modulus));
   }


### PR DESCRIPTION
I'm hoping that this workaround allows us to use libprio on Windows in spite of [NSS bug 1489691](https://bugzilla.mozilla.org/show_bug.cgi?id=1489691).

My hope is that both of the PRG implementations in this pull request (`PRG_SIMPLE` and `PRG_BUFFERING`) are 
1. Byte-compatible with each other and
1. Byte-compatible with the earlier PRG implementation.

If not, then Prio client packets encoded with one version of libprio will be unintelligible to a server using a different version of libprio. To try to ensure that I at least meet goal (1), I kept both the original implementation (`PRG_SIMPLE`) and the workaround (`PRG_BUFFERING`) so that we can easily test one against the other.

We could also just get rid of `PRG_SIMPLE` on all platforms, but ideally once the NSS folks fix the bug, we will be able to get rid of `PRG_BUFFERING` instead.