### PR TITLE
Linux distros expect NSS headers to not have nss/ prefix on include, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For macOS using Homebrew:
     $ brew install nss nspr scons msgpack
 
     $ export LINKFLAGS="-L/usr/local/opt/nss/lib"
-    $ export CPPFLAGS="-I/usr/local/opt/nss/include -I/usr/local/opt/nspr/include/nspr"
+    $ export CPPFLAGS="-I/usr/local/opt/nss/include/nss -I/usr/local/opt/nspr/include/nspr"
 
 To compile the code, run:
 

--- a/SConstruct
+++ b/SConstruct
@@ -28,7 +28,7 @@ env.Append(
   LIBS = ["mprio", "mpi", "nss3", "nspr4"],
   LIBPATH = ['#build/prio', "#build/mpi"],
   CFLAGS = [ "-Wall", "-Werror", "-Wextra", "-O3", "-std=c99", 
-    "-I/usr/include/nspr", "-Impi", "-DDO_PR_CLEANUP"])
+    "-I/usr/include/nspr", "-I/usr/include/nss", "-Impi", "-DDO_PR_CLEANUP"])
 
 env.Append(CPPPATH = ["#include", "#."])
 Export('env')

--- a/include/mprio.h
+++ b/include/mprio.h
@@ -14,9 +14,9 @@ extern "C" {
 #endif
 
 #include <msgpack.h>
-#include <nss/blapit.h>
-#include <nss/pk11pub.h>
-#include <nss/seccomon.h>
+#include <blapit.h>
+#include <pk11pub.h>
+#include <seccomon.h>
 #include <stdbool.h>
 #include <stddef.h>
 

--- a/include/mprio.h
+++ b/include/mprio.h
@@ -13,8 +13,8 @@
 extern "C" {
 #endif
 
-#include <msgpack.h>
 #include <blapit.h>
+#include <msgpack.h>
 #include <pk11pub.h>
 #include <seccomon.h>
 #include <stdbool.h>

--- a/prio/encrypt.c
+++ b/prio/encrypt.c
@@ -6,9 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <nss/keyhi.h>
-#include <nss/keythi.h>
-#include <nss/pk11pub.h>
+#include <keyhi.h>
+#include <keythi.h>
+#include <pk11pub.h>
 #include <prerror.h>
 
 #include "encrypt.h"

--- a/prio/prg.c
+++ b/prio/prg.c
@@ -7,8 +7,8 @@
  */
 
 #include <mprio.h>
-#include <nss/blapit.h>
-#include <nss/pk11pub.h>
+#include <blapit.h>
+#include <pk11pub.h>
 #include <string.h>
 
 #include "prg.h"

--- a/prio/prg.c
+++ b/prio/prg.c
@@ -6,8 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <mprio.h>
 #include <blapit.h>
+#include <mprio.h>
 #include <pk11pub.h>
 #include <string.h>
 

--- a/prio/prg.h
+++ b/prio/prg.h
@@ -10,7 +10,7 @@
 #define __PRG_H__
 
 #include <mpi.h>
-#include <nss/blapit.h>
+#include <blapit.h>
 #include <stdlib.h>
 
 #include "config.h"

--- a/prio/prg.h
+++ b/prio/prg.h
@@ -9,8 +9,8 @@
 #ifndef __PRG_H__
 #define __PRG_H__
 
-#include <mpi.h>
 #include <blapit.h>
+#include <mpi.h>
 #include <stdlib.h>
 
 #include "config.h"

--- a/prio/rand.c
+++ b/prio/rand.c
@@ -8,9 +8,9 @@
 
 #include <limits.h>
 #include <mprio.h>
-#include <prinit.h>
 #include <nss.h>
 #include <pk11pub.h>
+#include <prinit.h>
 
 #include "debug.h"
 #include "rand.h"

--- a/prio/rand.c
+++ b/prio/rand.c
@@ -8,9 +8,9 @@
 
 #include <limits.h>
 #include <mprio.h>
-#include <nspr/prinit.h>
-#include <nss/nss.h>
-#include <nss/pk11pub.h>
+#include <prinit.h>
+#include <nss.h>
+#include <pk11pub.h>
 
 #include "debug.h"
 #include "rand.h"

--- a/prio/rand.h
+++ b/prio/rand.h
@@ -10,7 +10,7 @@
 #define __RAND_H__
 
 #include <mpi.h>
-#include <nss/seccomon.h>
+#include <seccomon.h>
 #include <stdlib.h>
 
 /*

--- a/ptest/encrypt_test.c
+++ b/ptest/encrypt_test.c
@@ -7,11 +7,11 @@
  */
 
 #include <nspr.h>
-#include <nss/cert.h>
-#include <nss/keyhi.h>
-#include <nss/nss.h>
-#include <nss/pk11pub.h>
-#include <nss/secoidt.h>
+#include <cert.h>
+#include <keyhi.h>
+#include <nss.h>
+#include <pk11pub.h>
+#include <secoidt.h>
 
 #include "mutest.h"
 #include "prio/encrypt.h"

--- a/ptest/encrypt_test.c
+++ b/ptest/encrypt_test.c
@@ -6,9 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <nspr.h>
 #include <cert.h>
 #include <keyhi.h>
+#include <nspr.h>
 #include <nss.h>
 #include <pk11pub.h>
 #include <secoidt.h>


### PR DESCRIPTION
…see https://bugzilla.mozilla.org/show_bug.cgi?id=1491289