### PR TITLE
Use AddressSanitizer and UBSanitizer in ptest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ addons:
 
 script:
   - ./scripts/clang-format.sh
-  - scons
+  - scons DEBUG=1
   - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
   - ./build/ptest/ptest -v

--- a/SConstruct
+++ b/SConstruct
@@ -22,7 +22,10 @@ for flag in ["CCFLAGS", "CFLAGS", "CPPFLAGS", "CXXFLAGS", "LINKFLAGS"]:
 
 if env["DEBUG"]: 
     print("DEBUG MODE!")
-    env.Append(CCFLAGS = ["-g", "-DDEBUG"])
+    sanitizers = ['-fsanitize=address,undefined', \
+                  '-fno-sanitize-recover=undefined,integer,nullability']
+    env.Append(CCFLAGS = ["-g", "-DDEBUG"] + sanitizers,
+               LINKFLAGS = sanitizers)
 
 env.Append(
   LIBS = ["mprio", "mpi", "nss3", "nspr4"],


### PR DESCRIPTION
Per #44:
* In debug mode, enable clang's AddressSanitizer and UndefinedBehaviorSanitizer.
* Configure Travis to compile in debug mode.

These should catch some memory/C errors in testing.