### PR TITLE
Functions for import/export of private keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ before_install:
   - wget https://github.com/msgpack/msgpack-c/releases/download/cpp-3.1.0/msgpack-3.1.0.tar.gz
   - tar xf msgpack-3.1.0.tar.gz
   - cd msgpack-3.1.0 && cmake . && make && sudo make install && cd ../
+  - sudo apt-get install -y dpkg
+  - wget http://ftp.us.debian.org/debian/pool/main/n/nss/libnss3_3.39-1_amd64.deb
+  - sudo dpkg -i libnss3_3.39-1_amd64.deb
+  - wget http://ftp.us.debian.org/debian/pool/main/n/nss/libnss3-dev_3.39-1_amd64.deb
+  - sudo dpkg -i libnss3-dev_3.39-1_amd64.deb
 
 addons:
   apt:
     packages:
     - libnspr4-dev
-    - libnss3-dev
     - clang-format-3.9
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ addons:
 
 script:
   - ./scripts/clang-format.sh
-  - scons DEBUG=1
+  - scons DEBUG=1 SANITIZE=1
   - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
   - ./build/ptest/ptest -v

--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ the dominant costs of the system are:
 ## Running the code
 
 You must first install 
-[NSS/NSPR](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS), 
+[NSS/NSPR](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS)
+with NSPR version 4.13.1 (or newer?) and NSS version 3.35 (or newer?), 
 [SCons](http://scons.org/) version 3.0.1 (or newer?), and
 [msgpack-c](https://github.com/msgpack/msgpack-c) version 2.1.5 (or newer?).
-On Ubuntu, you can install NSS and scons with:
+
+On Ubuntu Bionic (18.04LTS), you can install NSS and scons with:
 
     $ sudo apt install scons libnspr4-dev libnss3-dev 
 

--- a/SConstruct
+++ b/SConstruct
@@ -8,6 +8,7 @@ import SCons
 opts = Variables()
 opts.AddVariables(
     BoolVariable("DEBUG", "Make debug build", 0),
+    BoolVariable("SANITIZE", "Use AddressSanitizer and UBSanitizer", 0),
     BoolVariable("VERBOSE", "Show full build information", 0))
 
 env = Environment(options = opts,
@@ -22,10 +23,12 @@ for flag in ["CCFLAGS", "CFLAGS", "CPPFLAGS", "CXXFLAGS", "LINKFLAGS"]:
 
 if env["DEBUG"]: 
     print("DEBUG MODE!")
+    env.Append(CCFLAGS = ["-g", "-DDEBUG"])
+
+if env["SANITIZE"]:
     sanitizers = ['-fsanitize=address,undefined', \
                   '-fno-sanitize-recover=undefined,integer,nullability']
-    env.Append(CCFLAGS = ["-g", "-DDEBUG"] + sanitizers,
-               LINKFLAGS = sanitizers)
+    env.Append(CCFLAGS = sanitizers, LINKFLAGS = sanitizers)
 
 env.Append(
   LIBS = ["mprio", "mpi", "nss3", "nspr4"],

--- a/include/mprio.h
+++ b/include/mprio.h
@@ -87,9 +87,9 @@ void Prio_clear();
  * caller passes in, so you may free the `batch_id` string as soon as
  * `PrioConfig_new` returns.
  */
-PrioConfig PrioConfig_new(int n_fields, PublicKey server_a, PublicKey server_b,
-                          const unsigned char* batch_id,
-                          unsigned int batch_id_len);
+PrioConfig PrioConfig_new(int nFields, PublicKey serverA, PublicKey serverB,
+                          const unsigned char* batchId,
+                          unsigned int batchIdLen);
 void PrioConfig_clear(PrioConfig cfg);
 int PrioConfig_numDataFields(const_PrioConfig cfg);
 
@@ -98,7 +98,7 @@ int PrioConfig_numDataFields(const_PrioConfig cfg);
  * useful for testing, but PrioClient_encode() will always fail when used with
  * this config.
  */
-PrioConfig PrioConfig_newTest(int n_fields);
+PrioConfig PrioConfig_newTest(int nFields);
 
 /*
  * We use the PublicKey and PrivateKey objects for public-key encryption. Each
@@ -108,34 +108,52 @@ PrioConfig PrioConfig_newTest(int n_fields);
 SECStatus Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey);
 
 /*
- * Import a new curve25519 public key from the raw bytes given. The key passed
- * in
- * as `data` should be of length `CURVE25519_KEY_LEN`. This function allocates
- * a new PublicKey object, which the caller must free using `PublicKey_clear`.
+ * Import a new curve25519 public/private key from the raw bytes given.  When
+ * inporting a private key, you must pass in the corresponding public key as
+ * well. The byte arrays given as input should be of length
+ * `CURVE25519_KEY_LEN`.
+ *
+ * These functions will allocate a new `PublicKey`/`PrivateKey` object, which
+ * the caller must free using `PublicKey_clear`/`PrivateKey_clear`.
  */
 SECStatus PublicKey_import(PublicKey* pk, const unsigned char* data,
                            unsigned int dataLen);
+SECStatus PrivateKey_import(PrivateKey* sk, const unsigned char* privData,
+                            unsigned int privDataLen,
+                            const unsigned char* pubData,
+                            unsigned int pubDataLen);
 
 /*
- * Import a new curve25519 public key from a hex string that contains only the
- * characters 0-9a-fA-F. The hex string passed in as `hex_data` should be of
- * length `CURVE25519_KEY_LEN_HEX`. This function allocates a new PublicKey
- * object, which the caller must free using `PublicKey_clear`.
+ * Import a new curve25519 public/private key from a hex string that contains
+ * only the characters 0-9a-fA-F.
+ *
+ * The hex strings passed in should each be of length `CURVE25519_KEY_LEN_HEX`.
+ * These functions will allocate a new `PublicKey`/`PrivateKey` object, which
+ * the caller must free using `PublicKey_clear`/`PrivateKey_clear`.
  */
-SECStatus PublicKey_import_hex(PublicKey* pk, const unsigned char* hex_data,
+SECStatus PublicKey_import_hex(PublicKey* pk, const unsigned char* hexData,
                                unsigned int dataLen);
+SECStatus PrivateKey_import_hex(PrivateKey* sk,
+                                const unsigned char* privHexData,
+                                unsigned int privDataLen,
+                                const unsigned char* pubHexData,
+                                unsigned int pubDataLen);
 
 /*
- * Export a curve25519 public key as a raw byte-array.
+ * Export a curve25519 key as a raw byte-array.
  */
 SECStatus PublicKey_export(const_PublicKey pk,
                            unsigned char data[CURVE25519_KEY_LEN]);
+SECStatus PrivateKey_export(PrivateKey sk,
+                            unsigned char data[CURVE25519_KEY_LEN]);
 
 /*
- * Export a curve25519 public key as a NULL-terminated hex string.
+ * Export a curve25519 key as a NULL-terminated hex string.
  */
 SECStatus PublicKey_export_hex(const_PublicKey pk,
                                unsigned char data[CURVE25519_KEY_LEN_HEX + 1]);
+SECStatus PrivateKey_export_hex(PrivateKey sk,
+                                unsigned char data[CURVE25519_KEY_LEN_HEX + 1]);
 
 void PublicKey_clear(PublicKey pubkey);
 void PrivateKey_clear(PrivateKey pvtkey);
@@ -152,8 +170,8 @@ void PrivateKey_clear(PrivateKey pvtkey);
  * `for_server_b` to avoid memory leaks.
  */
 SECStatus PrioClient_encode(const_PrioConfig cfg, const bool* data_in,
-                            unsigned char** for_server_a, unsigned int* aLen,
-                            unsigned char** for_server_b, unsigned int* bLen);
+                            unsigned char** forServerA, unsigned int* aLen,
+                            unsigned char** forServerB, unsigned int* bLen);
 
 /*
  * Generate a new PRG seed using the NSS global randomness source.
@@ -167,9 +185,9 @@ SECStatus PrioPRGSeed_randomize(PrioPRGSeed* seed);
  * Pass in the _same_ secret PRGSeed when initializing the two servers.
  * The PRGSeed must remain secret to the two servers.
  */
-PrioServer PrioServer_new(const_PrioConfig cfg, PrioServerId server_idx,
-                          PrivateKey server_priv,
-                          const PrioPRGSeed server_shared_secret);
+PrioServer PrioServer_new(const_PrioConfig cfg, PrioServerId serverIdx,
+                          PrivateKey serverPriv,
+                          const PrioPRGSeed serverSharedSecret);
 void PrioServer_clear(PrioServer s);
 
 /*

--- a/include/mprio.h
+++ b/include/mprio.h
@@ -109,7 +109,7 @@ SECStatus Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey);
 
 /*
  * Import a new curve25519 public/private key from the raw bytes given.  When
- * inporting a private key, you must pass in the corresponding public key as
+ * importing a private key, you must pass in the corresponding public key as
  * well. The byte arrays given as input should be of length
  * `CURVE25519_KEY_LEN`.
  *
@@ -127,7 +127,7 @@ SECStatus PrivateKey_import(PrivateKey* sk, const unsigned char* privData,
  * Import a new curve25519 public/private key from a hex string that contains
  * only the characters 0-9a-fA-F.
  *
- * The hex strings passed in should each be of length `CURVE25519_KEY_LEN_HEX`.
+ * The hex strings passed in must each be of length `CURVE25519_KEY_LEN_HEX`.
  * These functions will allocate a new `PublicKey`/`PrivateKey` object, which
  * the caller must free using `PublicKey_clear`/`PrivateKey_clear`.
  */
@@ -141,19 +141,24 @@ SECStatus PrivateKey_import_hex(PrivateKey* sk,
 
 /*
  * Export a curve25519 key as a raw byte-array.
+ *
+ * The output buffer `data` must have length exactly `CURVE25519_KEY_LEN`.
  */
-SECStatus PublicKey_export(const_PublicKey pk,
-                           unsigned char data[CURVE25519_KEY_LEN]);
-SECStatus PrivateKey_export(PrivateKey sk,
-                            unsigned char data[CURVE25519_KEY_LEN]);
+SECStatus PublicKey_export(const_PublicKey pk, unsigned char* data,
+                           unsigned int dataLen);
+SECStatus PrivateKey_export(PrivateKey sk, unsigned char* data,
+                            unsigned int dataLen);
 
 /*
  * Export a curve25519 key as a NULL-terminated hex string.
+ *
+ * The output buffer `data` must have length exactly `CURVE25519_KEY_LEN_HEX +
+ * 1`.
  */
-SECStatus PublicKey_export_hex(const_PublicKey pk,
-                               unsigned char data[CURVE25519_KEY_LEN_HEX + 1]);
-SECStatus PrivateKey_export_hex(PrivateKey sk,
-                                unsigned char data[CURVE25519_KEY_LEN_HEX + 1]);
+SECStatus PublicKey_export_hex(const_PublicKey pk, unsigned char* data,
+                               unsigned int dataLen);
+SECStatus PrivateKey_export_hex(PrivateKey sk, unsigned char* data,
+                                unsigned int dataLen);
 
 void PublicKey_clear(PublicKey pubkey);
 void PrivateKey_clear(PrivateKey pvtkey);

--- a/prio/encrypt.c
+++ b/prio/encrypt.c
@@ -26,8 +26,8 @@
 #define PRIO_TAG "PrioPacket"
 #define AAD_LEN (strlen(PRIO_TAG) + CURVE25519_KEY_LEN + GCM_IV_LEN_BYTES)
 
-// For an example import/export code, see:
-// https://searchfox.org/nss/source/gtests/pk11_gtest/pk11_curve25519_unittest.cc#66
+// For an example of NSS curve25519 import/export code, see:
+// https://searchfox.org/nss/rev/cfd5fcba7efbfe116e2c08848075240ec3a92718/gtests/pk11_gtest/pk11_curve25519_unittest.cc#66
 
 // The all-zeros curve25519 public key, as DER-encoded SPKI blob.
 static const uint8_t curve25519_spki_zeros[] = {
@@ -253,10 +253,11 @@ PrivateKey_import_hex(PrivateKey* sk, const unsigned char* privHexData,
 }
 
 SECStatus
-PublicKey_export(const_PublicKey pk, unsigned char data[CURVE25519_KEY_LEN])
+PublicKey_export(const_PublicKey pk, unsigned char* data, unsigned int dataLen)
 {
-  if (pk == NULL)
+  if (pk == NULL || dataLen != CURVE25519_KEY_LEN) {
     return SECFailure;
+  }
 
   const SECItem* key = &pk->u.ec.publicValue;
   if (key->len != CURVE25519_KEY_LEN) {
@@ -268,9 +269,9 @@ PublicKey_export(const_PublicKey pk, unsigned char data[CURVE25519_KEY_LEN])
 }
 
 SECStatus
-PrivateKey_export(PrivateKey sk, unsigned char data[CURVE25519_KEY_LEN])
+PrivateKey_export(PrivateKey sk, unsigned char* data, unsigned int dataLen)
 {
-  if (sk == NULL) {
+  if (sk == NULL || dataLen != CURVE25519_KEY_LEN) {
     return SECFailure;
   }
 
@@ -333,24 +334,33 @@ key_from_hex(unsigned char key_out[CURVE25519_KEY_LEN],
 }
 
 SECStatus
-PublicKey_export_hex(const_PublicKey pk,
-                     unsigned char data[(2 * CURVE25519_KEY_LEN) + 1])
+PublicKey_export_hex(const_PublicKey pk, unsigned char* data,
+                     unsigned int dataLen)
 {
-  unsigned char raw_data[CURVE25519_KEY_LEN];
-  if (PublicKey_export(pk, raw_data) != SECSuccess)
+  if (dataLen != CURVE25519_KEY_LEN_HEX + 1) {
     return SECFailure;
+  }
+
+  unsigned char raw_data[CURVE25519_KEY_LEN];
+  if (PublicKey_export(pk, raw_data, sizeof(raw_data)) != SECSuccess) {
+    return SECFailure;
+  }
 
   key_to_hex(raw_data, data);
   return SECSuccess;
 }
 
 SECStatus
-PrivateKey_export_hex(PrivateKey sk,
-                      unsigned char data[(2 * CURVE25519_KEY_LEN) + 1])
+PrivateKey_export_hex(PrivateKey sk, unsigned char* data, unsigned int dataLen)
 {
-  unsigned char raw_data[CURVE25519_KEY_LEN];
-  if (PrivateKey_export(sk, raw_data) != SECSuccess)
+  if (dataLen != CURVE25519_KEY_LEN_HEX + 1) {
     return SECFailure;
+  }
+
+  unsigned char raw_data[CURVE25519_KEY_LEN];
+  if (PrivateKey_export(sk, raw_data, sizeof(raw_data)) != SECSuccess) {
+    return SECFailure;
+  }
 
   key_to_hex(raw_data, data);
   return SECSuccess;

--- a/prio/encrypt.c
+++ b/prio/encrypt.c
@@ -26,7 +26,10 @@
 #define PRIO_TAG "PrioPacket"
 #define AAD_LEN (strlen(PRIO_TAG) + CURVE25519_KEY_LEN + GCM_IV_LEN_BYTES)
 
-// The all-zeros curve25519 public key, as DER-encoded SKPI blob.
+// For an example import/export code, see:
+// https://searchfox.org/nss/source/gtests/pk11_gtest/pk11_curve25519_unittest.cc#66
+
+// The all-zeros curve25519 public key, as DER-encoded SPKI blob.
 static const uint8_t curve25519_spki_zeros[] = {
   0x30, 0x39, 0x30, 0x14, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02,
   0x01, 0x06, 0x09, 0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f, 0x01,
@@ -34,6 +37,35 @@ static const uint8_t curve25519_spki_zeros[] = {
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
+
+// The all-zeros curve25519 private key, as a PKCS#8 blob.
+static const uint8_t curve25519_priv_zeros[] = {
+  0x30, 0x67, 0x02, 0x01, 0x00, 0x30, 0x14, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce,
+  0x3d, 0x02, 0x01, 0x06, 0x09, 0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f,
+  0x01, 0x04, 0x4c, 0x30, 0x4a, 0x02, 0x01, 0x01, 0x04, 0x20,
+
+  /* Byte index 36:  32 bytes of curve25519 private key. */
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+  /* misc type fields */
+  0xa1, 0x23, 0x03, 0x21,
+
+  /* Byte index 73:  32 bytes of curve25519 public key. */
+  0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+// Index into `curve25519_priv_zeros` at which the private key begins.
+static const size_t curve25519_priv_sk_offset = 36;
+// Index into `curve25519_priv_zeros` at which the public key begins.
+static const size_t curve25519_priv_pk_offset = 73;
+
+static SECStatus key_from_hex(
+  unsigned char key_out[CURVE25519_KEY_LEN],
+  const unsigned char hex_in[CURVE25519_KEY_LEN_HEX]);
 
 // Note that we do not use isxdigit because it is locale-dependent
 // See: https://github.com/mozilla/libprio/issues/20
@@ -106,6 +138,7 @@ PublicKey_import(PublicKey* pk, const unsigned char* data, unsigned int dataLen)
 
   const int spki_len = sizeof(curve25519_spki_zeros);
   P_CHECKA(spki_data = calloc(spki_len, sizeof(uint8_t)));
+
   memcpy(spki_data, curve25519_spki_zeros, spki_len);
   SECItem spki_item = { siBuffer, spki_data, spki_len };
 
@@ -131,28 +164,92 @@ cleanup:
 }
 
 SECStatus
-PublicKey_import_hex(PublicKey* pk, const unsigned char* hex_data,
+PrivateKey_import(PrivateKey* sk, const unsigned char* sk_data,
+                  unsigned int sk_data_len, const unsigned char* pk_data,
+                  unsigned int pk_data_len)
+{
+  if (sk_data_len != CURVE25519_KEY_LEN || !sk_data) {
+    return SECFailure;
+  }
+
+  if (pk_data_len != CURVE25519_KEY_LEN || !pk_data) {
+    return SECFailure;
+  }
+
+  SECStatus rv = SECSuccess;
+  PK11SlotInfo* slot = NULL;
+  uint8_t* zero_priv_data = NULL;
+  *sk = NULL;
+  const int zero_priv_len = sizeof(curve25519_priv_zeros);
+
+  P_CHECKA(slot = PK11_GetInternalSlot());
+
+  P_CHECKA(zero_priv_data = calloc(zero_priv_len, sizeof(uint8_t)));
+  SECItem zero_priv_item = { siBuffer, zero_priv_data, zero_priv_len };
+
+  // Copy the PKCS#8-encoded keypair into writable buffer.
+  memcpy(zero_priv_data, curve25519_priv_zeros, zero_priv_len);
+  // Copy private key into bytes beginning at index `curve25519_priv_sk_offset`.
+  memcpy(zero_priv_data + curve25519_priv_sk_offset, sk_data, sk_data_len);
+  // Copy private key into bytes beginning at index `curve25519_priv_pk_offset`.
+  memcpy(zero_priv_data + curve25519_priv_pk_offset, pk_data, pk_data_len);
+
+  P_CHECKC(PK11_ImportDERPrivateKeyInfoAndReturnKey(
+    slot, &zero_priv_item, NULL, NULL, PR_FALSE, PR_FALSE, KU_ALL, sk, NULL));
+
+cleanup:
+  if (slot) {
+    PK11_FreeSlot(slot);
+  }
+  if (zero_priv_data) {
+    free(zero_priv_data);
+  }
+  if (rv != SECSuccess) {
+    PrivateKey_clear(*sk);
+  }
+  return rv;
+}
+
+SECStatus
+PublicKey_import_hex(PublicKey* pk, const unsigned char* hexData,
                      unsigned int dataLen)
 {
   unsigned char raw_bytes[CURVE25519_KEY_LEN];
 
-  if (dataLen != CURVE25519_KEY_LEN_HEX)
+  if (dataLen != CURVE25519_KEY_LEN_HEX || !hexData) {
     return SECFailure;
-
-  for (unsigned int i = 0; i < dataLen; i++) {
-    if (!is_hex_digit(hex_data[i]))
-      return SECFailure;
   }
 
-  const unsigned char* p = hex_data;
-  for (unsigned int i = 0; i < CURVE25519_KEY_LEN; i++) {
-    uint8_t d0 = hex_to_int(p[0]);
-    uint8_t d1 = hex_to_int(p[1]);
-    raw_bytes[i] = (d0 << 4) | d1;
-    p += 2;
+  if (key_from_hex(raw_bytes, hexData) != SECSuccess) {
+    return SECFailure;
   }
 
   return PublicKey_import(pk, raw_bytes, CURVE25519_KEY_LEN);
+}
+
+SECStatus
+PrivateKey_import_hex(PrivateKey* sk, const unsigned char* privHexData,
+                      unsigned int privDataLen, const unsigned char* pubHexData,
+                      unsigned int pubDataLen)
+{
+  SECStatus rv = SECSuccess;
+  unsigned char raw_priv[CURVE25519_KEY_LEN];
+  unsigned char raw_pub[CURVE25519_KEY_LEN];
+
+  if (privDataLen != CURVE25519_KEY_LEN_HEX ||
+      pubDataLen != CURVE25519_KEY_LEN_HEX) {
+    return SECFailure;
+  }
+
+  if (!privHexData || !pubHexData) {
+    return SECFailure;
+  }
+
+  P_CHECK(key_from_hex(raw_priv, privHexData));
+  P_CHECK(key_from_hex(raw_pub, pubHexData));
+
+  return PrivateKey_import(sk, raw_priv, CURVE25519_KEY_LEN, raw_pub,
+                           CURVE25519_KEY_LEN);
 }
 
 SECStatus
@@ -161,7 +258,76 @@ PublicKey_export(const_PublicKey pk, unsigned char data[CURVE25519_KEY_LEN])
   if (pk == NULL)
     return SECFailure;
 
-  memcpy(data, pk->u.ec.publicValue.data, CURVE25519_KEY_LEN);
+  const SECItem* key = &pk->u.ec.publicValue;
+  if (key->len != CURVE25519_KEY_LEN) {
+    return SECFailure;
+  }
+
+  memcpy(data, key->data, key->len);
+  return SECSuccess;
+}
+
+SECStatus
+PrivateKey_export(PrivateKey sk, unsigned char data[CURVE25519_KEY_LEN])
+{
+  if (sk == NULL) {
+    return SECFailure;
+  }
+
+  SECStatus rv = SECSuccess;
+  SECItem item = { siBuffer, NULL, 0 };
+
+  P_CHECKC(PK11_ReadRawAttribute(PK11_TypePrivKey, sk, CKA_VALUE, &item));
+
+  // If the leading bytes of the key are '\0', then this string can be
+  // shorter than `CURVE25519_KEY_LEN` bytes.
+  memset(data, 0, CURVE25519_KEY_LEN);
+  P_CHECKCB(item.len <= CURVE25519_KEY_LEN);
+
+  // Copy into the low-order bytes of the output.
+  const size_t leading_zeros = CURVE25519_KEY_LEN - item.len;
+  memcpy(data + leading_zeros, item.data, item.len);
+
+cleanup:
+  if (item.data != NULL) {
+    SECITEM_ZfreeItem(&item, PR_FALSE);
+  }
+
+  return rv;
+}
+
+static void
+key_to_hex(const unsigned char key_in[CURVE25519_KEY_LEN],
+           unsigned char hex_out[(2 * CURVE25519_KEY_LEN) + 1])
+{
+  const unsigned char* p = key_in;
+  for (unsigned int i = 0; i < CURVE25519_KEY_LEN; i++) {
+    unsigned char bytel = p[0] & 0x0f;
+    unsigned char byteu = (p[0] & 0xf0) >> 4;
+    hex_out[2 * i] = int_to_hex(byteu);
+    hex_out[2 * i + 1] = int_to_hex(bytel);
+    p++;
+  }
+
+  hex_out[2 * CURVE25519_KEY_LEN] = '\0';
+}
+
+static SECStatus
+key_from_hex(unsigned char key_out[CURVE25519_KEY_LEN],
+             const unsigned char hex_in[CURVE25519_KEY_LEN_HEX])
+{
+  for (unsigned int i = 0; i < CURVE25519_KEY_LEN_HEX; i++) {
+    if (!is_hex_digit(hex_in[i]))
+      return SECFailure;
+  }
+
+  const unsigned char* p = hex_in;
+  for (unsigned int i = 0; i < CURVE25519_KEY_LEN; i++) {
+    uint8_t d0 = hex_to_int(p[0]);
+    uint8_t d1 = hex_to_int(p[1]);
+    key_out[i] = (d0 << 4) | d1;
+    p += 2;
+  }
 
   return SECSuccess;
 }
@@ -174,16 +340,19 @@ PublicKey_export_hex(const_PublicKey pk,
   if (PublicKey_export(pk, raw_data) != SECSuccess)
     return SECFailure;
 
-  const unsigned char* p = raw_data;
-  for (unsigned int i = 0; i < CURVE25519_KEY_LEN; i++) {
-    unsigned char bytel = p[0] & 0x0f;
-    unsigned char byteu = (p[0] & 0xf0) >> 4;
-    data[2 * i] = int_to_hex(byteu);
-    data[2 * i + 1] = int_to_hex(bytel);
-    p++;
-  }
+  key_to_hex(raw_data, data);
+  return SECSuccess;
+}
 
-  data[2 * CURVE25519_KEY_LEN] = '\0';
+SECStatus
+PrivateKey_export_hex(PrivateKey sk,
+                      unsigned char data[(2 * CURVE25519_KEY_LEN) + 1])
+{
+  unsigned char raw_data[CURVE25519_KEY_LEN];
+  if (PrivateKey_export(sk, raw_data) != SECSuccess)
+    return SECFailure;
+
+  key_to_hex(raw_data, data);
   return SECSuccess;
 }
 
@@ -220,11 +389,13 @@ Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey)
   P_CHECKA(*pvtkey = PK11_GenerateKeyPair(slot, CKM_EC_KEY_PAIR_GEN, &ecp,
                                           (SECKEYPublicKey**)pubkey, PR_FALSE,
                                           PR_FALSE, NULL));
-  PK11_FreeSlot(slot);
-
 cleanup:
-  if (ecp.data)
+  if (slot) {
+    PK11_FreeSlot(slot);
+  }
+  if (ecp.data) {
     free(ecp.data);
+  }
   if (rv != SECSuccess) {
     PublicKey_clear(*pubkey);
     PrivateKey_clear(*pvtkey);

--- a/ptest/client_test.c
+++ b/ptest/client_test.c
@@ -9,6 +9,7 @@
 #include <mprio.h>
 
 #include "mutest.h"
+#include "test_util.h"
 #include "prio/client.h"
 #include "prio/server.h"
 #include "prio/util.h"
@@ -22,19 +23,19 @@ mu_test_client__new(void)
   PrioPacketClient pB = NULL;
   bool* data_items = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(23));
-  P_CHECKA(pA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
-  P_CHECKA(pB = PrioPacketClient_new(cfg, PRIO_SERVER_B));
+  PT_CHECKA(cfg = PrioConfig_newTest(23));
+  PT_CHECKA(pA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
+  PT_CHECKA(pB = PrioPacketClient_new(cfg, PRIO_SERVER_B));
 
   const int ndata = PrioConfig_numDataFields(cfg);
-  P_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
 
   for (int i = 0; i < ndata; i++) {
     // Arbitrary data
     data_items[i] = (i % 3 == 1) || (i % 5 == 3);
   }
 
-  P_CHECKC(PrioPacketClient_set_data(cfg, data_items, pA, pB));
+  PT_CHECKC(PrioPacketClient_set_data(cfg, data_items, pA, pB));
 
 cleanup:
   mu_check(rv == SECSuccess);
@@ -69,21 +70,21 @@ test_client_agg(int nclients)
   unsigned long* output = NULL;
 
   PrioPRGSeed seed;
-  P_CHECKC(PrioPRGSeed_randomize(&seed));
+  PT_CHECKC(PrioPRGSeed_randomize(&seed));
 
-  P_CHECKC(Keypair_new(&skA, &pkA));
-  P_CHECKC(Keypair_new(&skB, &pkB));
-  P_CHECKA(cfg = PrioConfig_new(133, pkA, pkB, batch_id, batch_id_len));
-  P_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
-  P_CHECKA(sB = PrioServer_new(cfg, 1, skB, seed));
-  P_CHECKA(tA = PrioTotalShare_new());
-  P_CHECKA(tB = PrioTotalShare_new());
-  P_CHECKA(vA = PrioVerifier_new(sA));
-  P_CHECKA(vB = PrioVerifier_new(sB));
+  PT_CHECKC(Keypair_new(&skA, &pkA));
+  PT_CHECKC(Keypair_new(&skB, &pkB));
+  PT_CHECKA(cfg = PrioConfig_new(133, pkA, pkB, batch_id, batch_id_len));
+  PT_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
+  PT_CHECKA(sB = PrioServer_new(cfg, 1, skB, seed));
+  PT_CHECKA(tA = PrioTotalShare_new());
+  PT_CHECKA(tB = PrioTotalShare_new());
+  PT_CHECKA(vA = PrioVerifier_new(sA));
+  PT_CHECKA(vB = PrioVerifier_new(sB));
 
   const int ndata = PrioConfig_numDataFields(cfg);
 
-  P_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
   for (int i = 0; i < ndata; i++) {
     // Arbitrary data
     data_items[i] = (i % 3 == 1) || (i % 5 == 3);
@@ -91,10 +92,10 @@ test_client_agg(int nclients)
 
   for (int i = 0; i < nclients; i++) {
     unsigned int aLen, bLen;
-    P_CHECKC(PrioClient_encode(cfg, data_items, &for_a, &aLen, &for_b, &bLen));
+    PT_CHECKC(PrioClient_encode(cfg, data_items, &for_a, &aLen, &for_b, &bLen));
 
-    P_CHECKC(PrioVerifier_set_data(vA, for_a, aLen));
-    P_CHECKC(PrioVerifier_set_data(vB, for_b, bLen));
+    PT_CHECKC(PrioVerifier_set_data(vA, for_a, aLen));
+    PT_CHECKC(PrioVerifier_set_data(vB, for_b, bLen));
 
     mu_check(PrioServer_aggregate(sA, vA) == SECSuccess);
     mu_check(PrioServer_aggregate(sB, vB) == SECSuccess);
@@ -109,7 +110,7 @@ test_client_agg(int nclients)
   mu_check(PrioTotalShare_set_data(tA, sA) == SECSuccess);
   mu_check(PrioTotalShare_set_data(tB, sB) == SECSuccess);
 
-  P_CHECKA(output = calloc(ndata, sizeof(unsigned long)));
+  PT_CHECKA(output = calloc(ndata, sizeof(unsigned long)));
   mu_check(PrioTotalShare_final(cfg, output, tA, tB) == SECSuccess);
   for (int i = 0; i < ndata; i++) {
     unsigned long v = ((i % 3 == 1) || (i % 5 == 3));

--- a/ptest/client_test.c
+++ b/ptest/client_test.c
@@ -9,10 +9,10 @@
 #include <mprio.h>
 
 #include "mutest.h"
-#include "test_util.h"
 #include "prio/client.h"
 #include "prio/server.h"
 #include "prio/util.h"
+#include "test_util.h"
 
 void
 mu_test_client__new(void)

--- a/ptest/encrypt_test.c
+++ b/ptest/encrypt_test.c
@@ -14,10 +14,10 @@
 #include <secoidt.h>
 
 #include "mutest.h"
-#include "test_util.h"
 #include "prio/encrypt.h"
 #include "prio/rand.h"
 #include "prio/util.h"
+#include "test_util.h"
 
 void
 mu_test_keygen(void)
@@ -64,7 +64,7 @@ test_encrypt_once(int bad, unsigned int inlen)
   PT_CHECKC(Keypair_new(&pvtkey, &pubkey));
   PT_CHECKC(Keypair_new(&pvtkey2, &pubkey2));
   PT_CHECKC(PublicKey_encrypt(pubkey, bytes_enc, &encryptedBytes, enclen,
-                             bytes_in, inlen));
+                              bytes_in, inlen));
   mu_check(encryptedBytes == enclen);
 
   if (bad == 1)
@@ -220,8 +220,8 @@ test_export_privkey(int zeros)
     memset(privData, 0, 5);
   }
 
-  PT_CHECKC(PrivateKey_import(&pvtkey_imp, privData, CURVE25519_KEY_LEN, pubData,
-                             CURVE25519_KEY_LEN));
+  PT_CHECKC(PrivateKey_import(&pvtkey_imp, privData, CURVE25519_KEY_LEN,
+                              pubData, CURVE25519_KEY_LEN));
   PT_CHECKC(PrivateKey_export(pvtkey_imp, privData2));
 
   mu_check(!memcmp(privData, privData2, CURVE25519_KEY_LEN));
@@ -229,12 +229,12 @@ test_export_privkey(int zeros)
   if (!zeros) {
     unsigned int outputLen;
     PT_CHECKC(PublicKey_encrypt(pubkey, output, &outputLen, sizeof(output),
-                               input, sizeof(input)));
+                                input, sizeof(input)));
 
     // Check that can decrypt with imported private key.
     unsigned int plainLen;
-    PT_CHECKC(PrivateKey_decrypt(pvtkey_imp, decrypt, &plainLen, sizeof(decrypt),
-                                output, outputLen));
+    PT_CHECKC(PrivateKey_decrypt(pvtkey_imp, decrypt, &plainLen,
+                                 sizeof(decrypt), output, outputLen));
 
     mu_check(plainLen == sizeof(input));
     mu_check(!memcmp(input, decrypt, sizeof(input)));
@@ -288,7 +288,7 @@ test_export_hex_privkey(int zeros)
   }
 
   PT_CHECKC(PrivateKey_import_hex(&pvtkey_imp, privData, CURVE25519_KEY_LEN_HEX,
-                                 pubData, CURVE25519_KEY_LEN_HEX));
+                                  pubData, CURVE25519_KEY_LEN_HEX));
   PT_CHECKC(PrivateKey_export_hex(pvtkey_imp, privData2));
 
   mu_check(!memcmp(privData, privData2, CURVE25519_KEY_LEN));
@@ -296,12 +296,12 @@ test_export_hex_privkey(int zeros)
   if (!zeros) {
     unsigned int outputLen;
     PT_CHECKC(PublicKey_encrypt(pubkey, output, &outputLen, sizeof(output),
-                               input, sizeof(input)));
+                                input, sizeof(input)));
 
     // Check that can decrypt with imported private key.
     unsigned int plainLen;
-    PT_CHECKC(PrivateKey_decrypt(pvtkey_imp, decrypt, &plainLen, sizeof(decrypt),
-                                output, outputLen));
+    PT_CHECKC(PrivateKey_decrypt(pvtkey_imp, decrypt, &plainLen,
+                                 sizeof(decrypt), output, outputLen));
 
     mu_check(plainLen == sizeof(input));
     mu_check(!memcmp(input, decrypt, sizeof(input)));

--- a/ptest/encrypt_test.c
+++ b/ptest/encrypt_test.c
@@ -152,7 +152,7 @@ mu_test_export_pubkey(void)
   }
 
   PT_CHECKC(PublicKey_import(&pubkey, raw_bytes, CURVE25519_KEY_LEN));
-  PT_CHECKC(PublicKey_export(pubkey, raw_bytes2));
+  PT_CHECKC(PublicKey_export(pubkey, raw_bytes2, CURVE25519_KEY_LEN));
 
   for (int i = 0; i < CURVE25519_KEY_LEN; i++) {
     mu_check(raw_bytes[i] == raw_bytes2[i]);
@@ -181,7 +181,7 @@ mu_test_export_pubkey_zeros(void)
   }
 
   PT_CHECKC(PublicKey_import(&pubkey, raw_bytes, CURVE25519_KEY_LEN));
-  PT_CHECKC(PublicKey_export(pubkey, raw_bytes2));
+  PT_CHECKC(PublicKey_export(pubkey, raw_bytes2, CURVE25519_KEY_LEN));
 
   for (int i = 0; i < CURVE25519_KEY_LEN; i++) {
     mu_check(raw_bytes[i] == raw_bytes2[i]);
@@ -212,8 +212,8 @@ test_export_privkey(int zeros)
   }
 
   PT_CHECKC(Keypair_new(&pvtkey, &pubkey));
-  PT_CHECKC(PrivateKey_export(pvtkey, privData));
-  PT_CHECKC(PublicKey_export(pubkey, pubData));
+  PT_CHECKC(PrivateKey_export(pvtkey, privData, CURVE25519_KEY_LEN));
+  PT_CHECKC(PublicKey_export(pubkey, pubData, CURVE25519_KEY_LEN));
 
   if (zeros) {
     // Zero out leading bytes of private key
@@ -222,7 +222,7 @@ test_export_privkey(int zeros)
 
   PT_CHECKC(PrivateKey_import(&pvtkey_imp, privData, CURVE25519_KEY_LEN,
                               pubData, CURVE25519_KEY_LEN));
-  PT_CHECKC(PrivateKey_export(pvtkey_imp, privData2));
+  PT_CHECKC(PrivateKey_export(pvtkey_imp, privData2, CURVE25519_KEY_LEN));
 
   mu_check(!memcmp(privData, privData2, CURVE25519_KEY_LEN));
 
@@ -279,8 +279,9 @@ test_export_hex_privkey(int zeros)
   }
 
   PT_CHECKC(Keypair_new(&pvtkey, &pubkey));
-  PT_CHECKC(PrivateKey_export_hex(pvtkey, privData));
-  PT_CHECKC(PublicKey_export_hex(pubkey, pubData));
+  PT_CHECKC(
+    PrivateKey_export_hex(pvtkey, privData, CURVE25519_KEY_LEN_HEX + 1));
+  PT_CHECKC(PublicKey_export_hex(pubkey, pubData, CURVE25519_KEY_LEN_HEX + 1));
 
   if (zeros) {
     // Zero out leading bytes of private key with ASCII zero
@@ -289,7 +290,8 @@ test_export_hex_privkey(int zeros)
 
   PT_CHECKC(PrivateKey_import_hex(&pvtkey_imp, privData, CURVE25519_KEY_LEN_HEX,
                                   pubData, CURVE25519_KEY_LEN_HEX));
-  PT_CHECKC(PrivateKey_export_hex(pvtkey_imp, privData2));
+  PT_CHECKC(
+    PrivateKey_export_hex(pvtkey_imp, privData2, CURVE25519_KEY_LEN_HEX + 1));
 
   mu_check(!memcmp(privData, privData2, CURVE25519_KEY_LEN));
 
@@ -373,7 +375,7 @@ mu_test_export_hex(void)
 
   // Import a key in upper-case hex
   PT_CHECKC(PublicKey_import_hex(&pubkey, hex_bytes, 2 * CURVE25519_KEY_LEN));
-  PT_CHECKC(PublicKey_export(pubkey, raw_bytes));
+  PT_CHECKC(PublicKey_export(pubkey, raw_bytes, CURVE25519_KEY_LEN));
   PublicKey_clear(pubkey);
   pubkey = NULL;
 
@@ -383,7 +385,7 @@ mu_test_export_hex(void)
 
   // Import a key in mixed-case hex
   PT_CHECKC(PublicKey_import_hex(&pubkey, hex_bytesl, 2 * CURVE25519_KEY_LEN));
-  PT_CHECKC(PublicKey_export(pubkey, raw_bytes));
+  PT_CHECKC(PublicKey_export(pubkey, raw_bytes, CURVE25519_KEY_LEN));
   PublicKey_clear(pubkey);
   pubkey = NULL;
 
@@ -398,7 +400,8 @@ mu_test_export_hex(void)
 
   // Import a raw key and export as hex
   PT_CHECKC(PublicKey_import(&pubkey, raw_bytes_should, CURVE25519_KEY_LEN));
-  PT_CHECKC(PublicKey_export_hex(pubkey, hex_bytes2));
+  PT_CHECKC(
+    PublicKey_export_hex(pubkey, hex_bytes2, CURVE25519_KEY_LEN_HEX + 1));
 
   for (int i = 0; i < 2 * CURVE25519_KEY_LEN; i++) {
     mu_check(hex_bytes[i] == hex_bytes2[i]);

--- a/ptest/fft_test.c
+++ b/ptest/fft_test.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 
 #include "mutest.h"
+#include "test_util.h"
 #include "prio/config.h"
 #include "prio/mparray.h"
 #include "prio/poly.h"
@@ -24,9 +25,9 @@ mu_test__fft_one(void)
   MPArray points_in = NULL;
   MPArray points_out = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(123));
-  P_CHECKA(points_in = MPArray_new(1));
-  P_CHECKA(points_out = MPArray_new(1));
+  PT_CHECKA(cfg = PrioConfig_newTest(123));
+  PT_CHECKA(points_in = MPArray_new(1));
+  PT_CHECKA(points_out = MPArray_new(1));
 
   mp_set(&points_in->data[0], 3);
   mu_check(poly_fft(points_out, points_in, cfg, false) == SECSuccess);
@@ -50,8 +51,8 @@ mu_test__fft_roots(void)
   mp_int tmp;
   MP_DIGITS(&tmp) = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(90));
-  MP_CHECKC(mp_init(&tmp));
+  PT_CHECKA(cfg = PrioConfig_newTest(90));
+  MPT_CHECKC(mp_init(&tmp));
 
   mp_int roots[4];
   poly_fft_get_roots(roots, 4, cfg, false);
@@ -82,13 +83,13 @@ mu_test__fft_simple(void)
   MP_DIGITS(&should_be) = NULL;
   MP_DIGITS(&tmp) = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(140));
-  P_CHECKA(points_in = MPArray_new(nPoints));
-  P_CHECKA(points_out = MPArray_new(nPoints));
-  P_CHECKA(roots = calloc(nPoints, sizeof(mp_int)));
+  PT_CHECKA(cfg = PrioConfig_newTest(140));
+  PT_CHECKA(points_in = MPArray_new(nPoints));
+  PT_CHECKA(points_out = MPArray_new(nPoints));
+  PT_CHECKA(roots = calloc(nPoints, sizeof(mp_int)));
 
-  MP_CHECKC(mp_init(&should_be));
-  MP_CHECKC(mp_init(&tmp));
+  MPT_CHECKC(mp_init(&should_be));
+  MPT_CHECKC(mp_init(&tmp));
 
   poly_fft_get_roots(roots, nPoints, cfg, false);
 
@@ -141,11 +142,11 @@ mu_test__fft_invert(void)
   MPArray points_out2 = NULL;
   mp_int* roots = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(91));
-  P_CHECKA(points_in = MPArray_new(nPoints));
-  P_CHECKA(points_out = MPArray_new(nPoints));
-  P_CHECKA(points_out2 = MPArray_new(nPoints));
-  P_CHECKA(roots = calloc(nPoints, sizeof(mp_int)));
+  PT_CHECKA(cfg = PrioConfig_newTest(91));
+  PT_CHECKA(points_in = MPArray_new(nPoints));
+  PT_CHECKA(points_out = MPArray_new(nPoints));
+  PT_CHECKA(points_out2 = MPArray_new(nPoints));
+  PT_CHECKA(roots = calloc(nPoints, sizeof(mp_int)));
 
   poly_fft_get_roots(roots, nPoints, cfg, false);
 

--- a/ptest/fft_test.c
+++ b/ptest/fft_test.c
@@ -11,11 +11,11 @@
 #include <stdio.h>
 
 #include "mutest.h"
-#include "test_util.h"
 #include "prio/config.h"
 #include "prio/mparray.h"
 #include "prio/poly.h"
 #include "prio/util.h"
+#include "test_util.h"
 
 void
 mu_test__fft_one(void)

--- a/ptest/prg_test.c
+++ b/ptest/prg_test.c
@@ -9,6 +9,7 @@
 #include <mpi.h>
 
 #include "mutest.h"
+#include "test_util.h"
 #include "prio/prg.h"
 #include "prio/util.h"
 
@@ -19,8 +20,8 @@ mu_test__prg_simple(void)
   PrioPRGSeed key;
   PRG prg = NULL;
 
-  P_CHECKC(PrioPRGSeed_randomize(&key));
-  P_CHECKA(prg = PRG_new(key));
+  PT_CHECKC(PrioPRGSeed_randomize(&key));
+  PT_CHECKA(prg = PRG_new(key));
 
 cleanup:
   mu_check(rv == SECSuccess);
@@ -39,17 +40,17 @@ mu_test__prg_repeat(void)
   PRG prg1 = NULL;
   PRG prg2 = NULL;
 
-  P_CHECKC(PrioPRGSeed_randomize(&key));
-  P_CHECKA(prg1 = PRG_new(key));
-  P_CHECKA(prg2 = PRG_new(key));
-  P_CHECKA(buf1 = calloc(buflen, sizeof(unsigned char)));
-  P_CHECKA(buf2 = calloc(buflen, sizeof(unsigned char)));
+  PT_CHECKC(PrioPRGSeed_randomize(&key));
+  PT_CHECKA(prg1 = PRG_new(key));
+  PT_CHECKA(prg2 = PRG_new(key));
+  PT_CHECKA(buf1 = calloc(buflen, sizeof(unsigned char)));
+  PT_CHECKA(buf2 = calloc(buflen, sizeof(unsigned char)));
 
   buf1[3] = 'a';
   buf2[3] = 'b';
 
-  P_CHECKC(PRG_get_bytes(prg1, buf1, buflen));
-  P_CHECKC(PRG_get_bytes(prg2, buf2, buflen));
+  PT_CHECKC(PRG_get_bytes(prg1, buf1, buflen));
+  PT_CHECKC(PRG_get_bytes(prg2, buf2, buflen));
 
   bool all_zero = true;
   for (int i = 0; i < buflen; i++) {
@@ -85,18 +86,18 @@ mu_test__prg_repeat_int(void)
   PRG prg1 = NULL;
   PRG prg2 = NULL;
 
-  P_CHECKC(PrioPRGSeed_randomize(&key));
-  P_CHECKA(prg1 = PRG_new(key));
-  P_CHECKA(prg2 = PRG_new(key));
+  PT_CHECKC(PrioPRGSeed_randomize(&key));
+  PT_CHECKA(prg1 = PRG_new(key));
+  PT_CHECKA(prg2 = PRG_new(key));
 
-  MP_CHECKC(mp_init(&max));
-  MP_CHECKC(mp_init(&out1));
-  MP_CHECKC(mp_init(&out2));
+  MPT_CHECKC(mp_init(&max));
+  MPT_CHECKC(mp_init(&out1));
+  MPT_CHECKC(mp_init(&out2));
 
   for (int i = 0; i < tries; i++) {
     mp_set(&max, i + 1);
-    P_CHECKC(PRG_get_int(prg1, &out1, &max));
-    P_CHECKC(PRG_get_int(prg2, &out2, &max));
+    PT_CHECKC(PRG_get_int(prg1, &out1, &max));
+    PT_CHECKC(PRG_get_int(prg2, &out2, &max));
     mu_check(mp_cmp(&out1, &out2) == 0);
   }
 
@@ -121,15 +122,15 @@ test_prg_once(int limit)
   MP_DIGITS(&max) = NULL;
   MP_DIGITS(&out) = NULL;
 
-  P_CHECKC(PrioPRGSeed_randomize(&key));
-  P_CHECKA(prg = PRG_new(key));
+  PT_CHECKC(PrioPRGSeed_randomize(&key));
+  PT_CHECKA(prg = PRG_new(key));
 
-  MP_CHECKC(mp_init(&max));
-  MP_CHECKC(mp_init(&out));
+  MPT_CHECKC(mp_init(&max));
+  MPT_CHECKC(mp_init(&out));
 
   mp_set(&max, limit);
 
-  P_CHECKC(PRG_get_int(prg, &out, &max));
+  PT_CHECKC(PRG_get_int(prg, &out, &max));
   mu_check(mp_cmp_d(&out, limit) == -1);
   mu_check(mp_cmp_z(&out) > -1);
 
@@ -189,12 +190,12 @@ test_prg_distribution(int limit)
   MP_DIGITS(&max) = NULL;
   MP_DIGITS(&out) = NULL;
 
-  P_CHECKC(PrioPRGSeed_randomize(&key));
-  P_CHECKA(prg = PRG_new(key));
-  P_CHECKA(bins = calloc(limit, sizeof(int)));
+  PT_CHECKC(PrioPRGSeed_randomize(&key));
+  PT_CHECKA(prg = PRG_new(key));
+  PT_CHECKA(bins = calloc(limit, sizeof(int)));
 
-  MP_CHECKC(mp_init(&max));
-  MP_CHECKC(mp_init(&out));
+  MPT_CHECKC(mp_init(&max));
+  MPT_CHECKC(mp_init(&out));
 
   mp_set(&max, limit);
 
@@ -203,12 +204,12 @@ test_prg_distribution(int limit)
   }
 
   for (int i = 0; i < limit * limit; i++) {
-    P_CHECKC(PRG_get_int(prg, &out, &max));
+    PT_CHECKC(PRG_get_int(prg, &out, &max));
     mu_check(mp_cmp_d(&out, limit) == -1);
     mu_check(mp_cmp_z(&out) > -1);
 
     unsigned char ival[2] = { 0x00, 0x00 };
-    MP_CHECKC(mp_to_fixlen_octets(&out, ival, 2));
+    MPT_CHECKC(mp_to_fixlen_octets(&out, ival, 2));
     if (ival[1] + 256 * ival[0] < limit) {
       bins[ival[1] + 256 * ival[0]] += 1;
     } else {
@@ -259,23 +260,23 @@ test_prg_distribution_large(mp_int* max)
 
   MP_DIGITS(&out) = NULL;
 
-  P_CHECKC(PrioPRGSeed_randomize(&key));
-  P_CHECKA(prg = PRG_new(key));
-  P_CHECKA(bins = calloc(limit, sizeof(int)));
+  PT_CHECKC(PrioPRGSeed_randomize(&key));
+  PT_CHECKA(prg = PRG_new(key));
+  PT_CHECKA(bins = calloc(limit, sizeof(int)));
 
-  MP_CHECKC(mp_init(&out));
+  MPT_CHECKC(mp_init(&out));
 
   for (int i = 0; i < limit; i++) {
     bins[i] = 0;
   }
 
   for (int i = 0; i < 100 * limit * limit; i++) {
-    MP_CHECKC(PRG_get_int(prg, &out, max));
+    MPT_CHECKC(PRG_get_int(prg, &out, max));
     mu_check(mp_cmp(&out, max) == -1);
     mu_check(mp_cmp_z(&out) > -1);
 
     unsigned long res;
-    MP_CHECKC(mp_mod_d(&out, limit, &res));
+    MPT_CHECKC(mp_mod_d(&out, limit, &res));
     bins[res] += 1;
   }
 
@@ -297,10 +298,10 @@ mu_test__prg_distribution_large(void)
   SECStatus rv = SECSuccess;
   mp_int max;
   MP_DIGITS(&max) = NULL;
-  MP_CHECKC(mp_init(&max));
+  MPT_CHECKC(mp_init(&max));
 
   char bytes[] = "FF1230985198451798EDC8123";
-  MP_CHECKC(mp_read_radix(&max, bytes, 16));
+  MPT_CHECKC(mp_read_radix(&max, bytes, 16));
   test_prg_distribution_large(&max);
 
 cleanup:
@@ -318,27 +319,27 @@ mu_test__prg_share_arr(void)
   PRG prg = NULL;
   PrioPRGSeed seed;
 
-  P_CHECKA(cfg = PrioConfig_newTest(72));
-  P_CHECKC(PrioPRGSeed_randomize(&seed));
-  P_CHECKA(arr = MPArray_new(10));
-  P_CHECKA(arr_share = MPArray_new(10));
-  P_CHECKA(prg = PRG_new(seed));
+  PT_CHECKA(cfg = PrioConfig_newTest(72));
+  PT_CHECKC(PrioPRGSeed_randomize(&seed));
+  PT_CHECKA(arr = MPArray_new(10));
+  PT_CHECKA(arr_share = MPArray_new(10));
+  PT_CHECKA(prg = PRG_new(seed));
 
   for (int i = 0; i < 10; i++) {
     mp_set(&arr->data[i], i);
   }
 
-  P_CHECKC(PRG_share_array(prg, arr_share, arr, cfg));
+  PT_CHECKC(PRG_share_array(prg, arr_share, arr, cfg));
 
   // Reset PRG
   PRG_clear(prg);
-  P_CHECKA(prg = PRG_new(seed));
+  PT_CHECKA(prg = PRG_new(seed));
 
   // Read pseudorandom values into arr
-  P_CHECKC(PRG_get_array(prg, arr, &cfg->modulus));
+  PT_CHECKC(PRG_get_array(prg, arr, &cfg->modulus));
 
   for (int i = 0; i < 10; i++) {
-    MP_CHECKC(mp_addmod(&arr->data[i], &arr_share->data[i], &cfg->modulus,
+    MPT_CHECKC(mp_addmod(&arr->data[i], &arr_share->data[i], &cfg->modulus,
                         &arr->data[i]));
     mu_check(mp_cmp_d(&arr->data[i], i) == 0);
   }

--- a/ptest/prg_test.c
+++ b/ptest/prg_test.c
@@ -9,9 +9,9 @@
 #include <mpi.h>
 
 #include "mutest.h"
-#include "test_util.h"
 #include "prio/prg.h"
 #include "prio/util.h"
+#include "test_util.h"
 
 void
 mu_test__prg_simple(void)
@@ -340,7 +340,7 @@ mu_test__prg_share_arr(void)
 
   for (int i = 0; i < 10; i++) {
     MPT_CHECKC(mp_addmod(&arr->data[i], &arr_share->data[i], &cfg->modulus,
-                        &arr->data[i]));
+                         &arr->data[i]));
     mu_check(mp_cmp_d(&arr->data[i], i) == 0);
   }
 

--- a/ptest/rand_test.c
+++ b/ptest/rand_test.c
@@ -9,6 +9,8 @@
 #include <mpi.h>
 
 #include "mutest.h"
+#include "test_util.h"
+#include "test_util.h"
 #include "prio/rand.h"
 #include "prio/util.h"
 
@@ -89,10 +91,10 @@ test_rand_distribution(int limit)
   MP_DIGITS(&max) = NULL;
   MP_DIGITS(&out) = NULL;
 
-  P_CHECKA(bins = calloc(limit, sizeof(int)));
+  PT_CHECKA(bins = calloc(limit, sizeof(int)));
 
-  MP_CHECKC(mp_init(&max));
-  MP_CHECKC(mp_init(&out));
+  MPT_CHECKC(mp_init(&max));
+  MPT_CHECKC(mp_init(&out));
 
   mp_set(&max, limit);
 
@@ -106,7 +108,7 @@ test_rand_distribution(int limit)
     mu_check(mp_cmp_z(&out) > -1);
 
     unsigned char ival[2] = { 0x00, 0x00 };
-    MP_CHECKC(mp_to_fixlen_octets(&out, ival, 2));
+    MPT_CHECKC(mp_to_fixlen_octets(&out, ival, 2));
     if (ival[1] + 256 * ival[0] < limit) {
       bins[ival[1] + 256 * ival[0]] += 1;
     } else {
@@ -153,20 +155,20 @@ test_rand_distribution_large(mp_int* max)
 
   mp_int out;
   MP_DIGITS(&out) = NULL;
-  MP_CHECKC(mp_init(&out));
-  P_CHECKA(bins = calloc(limit, sizeof(int)));
+  MPT_CHECKC(mp_init(&out));
+  PT_CHECKA(bins = calloc(limit, sizeof(int)));
 
   for (int i = 0; i < limit; i++) {
     bins[i] = 0;
   }
 
   for (int i = 0; i < 100 * limit * limit; i++) {
-    MP_CHECKC(rand_int(&out, max));
+    MPT_CHECKC(rand_int(&out, max));
     mu_check(mp_cmp(&out, max) == -1);
     mu_check(mp_cmp_z(&out) > -1);
 
     unsigned long res;
-    MP_CHECKC(mp_mod_d(&out, limit, &res));
+    MPT_CHECKC(mp_mod_d(&out, limit, &res));
     bins[res] += 1;
   }
 
@@ -187,10 +189,10 @@ mu_test__rand_distribution_large(void)
   SECStatus rv = SECSuccess;
   mp_int max;
   MP_DIGITS(&max) = NULL;
-  MP_CHECKC(mp_init(&max));
+  MPT_CHECKC(mp_init(&max));
 
   char bytes[] = "FF1230985198451798EDC8123";
-  MP_CHECKC(mp_read_radix(&max, bytes, 16));
+  MPT_CHECKC(mp_read_radix(&max, bytes, 16));
   test_rand_distribution_large(&max);
 
 cleanup:

--- a/ptest/rand_test.c
+++ b/ptest/rand_test.c
@@ -9,10 +9,10 @@
 #include <mpi.h>
 
 #include "mutest.h"
-#include "test_util.h"
-#include "test_util.h"
 #include "prio/rand.h"
 #include "prio/util.h"
+#include "test_util.h"
+#include "test_util.h"
 
 void
 mu_test__util_msb_mast(void)

--- a/ptest/serial_test.c
+++ b/ptest/serial_test.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "mutest.h"
+#include "test_util.h"
 #include "prio/client.h"
 #include "prio/config.h"
 #include "prio/serial.h"
@@ -25,13 +26,13 @@ gen_client_packets(const_PrioConfig cfg, PrioPacketClient pA,
 
   const int ndata = cfg->num_data_fields;
   bool* data_items = NULL;
-  P_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
 
   for (int i = 0; i < ndata; i++) {
     data_items[i] = (i % 3 == 1) || (i % 5 == 3);
   }
 
-  P_CHECKC(PrioPacketClient_set_data(cfg, data_items, pA, pB));
+  PT_CHECKC(PrioPacketClient_set_data(cfg, data_items, pA, pB));
 
 cleanup:
   if (data_items)
@@ -64,17 +65,17 @@ serial_client(int bad)
   msgpack_sbuffer_init(&sbufB);
   msgpack_packer_init(&pkB, &sbufB, msgpack_sbuffer_write);
 
-  P_CHECKA(cfg = PrioConfig_new(100, NULL, NULL, batch_id1, batch_id_len));
-  P_CHECKA(cfg2 = PrioConfig_new(100, NULL, NULL, batch_id2, batch_id_len));
-  P_CHECKA(pA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
-  P_CHECKA(pB = PrioPacketClient_new(cfg, PRIO_SERVER_B));
-  P_CHECKA(qA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
-  P_CHECKA(qB = PrioPacketClient_new(cfg, PRIO_SERVER_B));
+  PT_CHECKA(cfg = PrioConfig_new(100, NULL, NULL, batch_id1, batch_id_len));
+  PT_CHECKA(cfg2 = PrioConfig_new(100, NULL, NULL, batch_id2, batch_id_len));
+  PT_CHECKA(pA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
+  PT_CHECKA(pB = PrioPacketClient_new(cfg, PRIO_SERVER_B));
+  PT_CHECKA(qA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
+  PT_CHECKA(qB = PrioPacketClient_new(cfg, PRIO_SERVER_B));
 
-  P_CHECKC(gen_client_packets(cfg, pA, pB));
+  PT_CHECKC(gen_client_packets(cfg, pA, pB));
 
-  P_CHECKC(serial_write_packet_client(&pkA, pA, cfg));
-  P_CHECKC(serial_write_packet_client(&pkB, pB, cfg));
+  PT_CHECKC(serial_write_packet_client(&pkA, pA, cfg));
+  PT_CHECKC(serial_write_packet_client(&pkB, pB, cfg));
 
   if (bad == 1) {
     sbufA.size = 1;
@@ -87,11 +88,11 @@ serial_client(int bad)
   const int size_a = sbufA.size;
   const int size_b = sbufB.size;
 
-  P_CHECKCB(msgpack_unpacker_init(&upkA, 0));
-  P_CHECKCB(msgpack_unpacker_init(&upkB, 0));
+  PT_CHECKCB(msgpack_unpacker_init(&upkA, 0));
+  PT_CHECKCB(msgpack_unpacker_init(&upkB, 0));
 
-  P_CHECKCB(msgpack_unpacker_reserve_buffer(&upkA, size_a));
-  P_CHECKCB(msgpack_unpacker_reserve_buffer(&upkB, size_b));
+  PT_CHECKCB(msgpack_unpacker_reserve_buffer(&upkA, size_a));
+  PT_CHECKCB(msgpack_unpacker_reserve_buffer(&upkB, size_b));
 
   memcpy(msgpack_unpacker_buffer(&upkA), sbufA.data, size_a);
   memcpy(msgpack_unpacker_buffer(&upkB), sbufB.data, size_b);
@@ -155,9 +156,9 @@ test_verify1(int bad)
   PrioPacketVerify1 v2 = NULL;
   PrioConfig cfg = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(1));
-  P_CHECKA(v1 = PrioPacketVerify1_new());
-  P_CHECKA(v2 = PrioPacketVerify1_new());
+  PT_CHECKA(cfg = PrioConfig_newTest(1));
+  PT_CHECKA(v1 = PrioPacketVerify1_new());
+  PT_CHECKA(v2 = PrioPacketVerify1_new());
   mp_set(&v1->share_d, 4);
   mp_set(&v1->share_e, 10);
 
@@ -168,14 +169,14 @@ test_verify1(int bad)
   msgpack_sbuffer_init(&sbuf);
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-  P_CHECKC(PrioPacketVerify1_write(v1, &pk));
+  PT_CHECKC(PrioPacketVerify1_write(v1, &pk));
 
   if (bad == 1) {
     mp_set(&cfg->modulus, 6);
   }
 
-  P_CHECKCB(msgpack_unpacker_init(&upk, 0));
-  P_CHECKCB(msgpack_unpacker_reserve_buffer(&upk, sbuf.size));
+  PT_CHECKCB(msgpack_unpacker_init(&upk, 0));
+  PT_CHECKCB(msgpack_unpacker_reserve_buffer(&upk, sbuf.size));
   memcpy(msgpack_unpacker_buffer(&upk), sbuf.data, sbuf.size);
   msgpack_unpacker_buffer_consumed(&upk, sbuf.size);
 
@@ -215,9 +216,9 @@ test_verify2(int bad)
   PrioPacketVerify2 v2 = NULL;
   PrioConfig cfg = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(1));
-  P_CHECKA(v1 = PrioPacketVerify2_new());
-  P_CHECKA(v2 = PrioPacketVerify2_new());
+  PT_CHECKA(cfg = PrioConfig_newTest(1));
+  PT_CHECKA(v1 = PrioPacketVerify2_new());
+  PT_CHECKA(v2 = PrioPacketVerify2_new());
   mp_set(&v1->share_out, 4);
 
   msgpack_sbuffer sbuf;
@@ -227,14 +228,14 @@ test_verify2(int bad)
   msgpack_sbuffer_init(&sbuf);
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-  P_CHECKC(PrioPacketVerify2_write(v1, &pk));
+  PT_CHECKC(PrioPacketVerify2_write(v1, &pk));
 
   if (bad == 1) {
     mp_set(&cfg->modulus, 4);
   }
 
-  P_CHECKCB(msgpack_unpacker_init(&upk, 0));
-  P_CHECKCB(msgpack_unpacker_reserve_buffer(&upk, sbuf.size));
+  PT_CHECKCB(msgpack_unpacker_init(&upk, 0));
+  PT_CHECKCB(msgpack_unpacker_reserve_buffer(&upk, sbuf.size));
   memcpy(msgpack_unpacker_buffer(&upk), sbuf.data, sbuf.size);
   msgpack_unpacker_buffer_consumed(&upk, sbuf.size);
 
@@ -272,12 +273,12 @@ test_total_share(int bad)
   PrioTotalShare t2 = NULL;
   PrioConfig cfg = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest((bad == 2 ? 4 : 3)));
-  P_CHECKA(t1 = PrioTotalShare_new());
-  P_CHECKA(t2 = PrioTotalShare_new());
+  PT_CHECKA(cfg = PrioConfig_newTest((bad == 2 ? 4 : 3)));
+  PT_CHECKA(t1 = PrioTotalShare_new());
+  PT_CHECKA(t2 = PrioTotalShare_new());
 
   t1->idx = PRIO_SERVER_A;
-  P_CHECKC(MPArray_resize(t1->data_shares, 3));
+  PT_CHECKC(MPArray_resize(t1->data_shares, 3));
 
   mp_set(&t1->data_shares->data[0], 10);
   mp_set(&t1->data_shares->data[1], 20);
@@ -290,14 +291,14 @@ test_total_share(int bad)
   msgpack_sbuffer_init(&sbuf);
   msgpack_packer_init(&pk, &sbuf, msgpack_sbuffer_write);
 
-  P_CHECKC(PrioTotalShare_write(t1, &pk));
+  PT_CHECKC(PrioTotalShare_write(t1, &pk));
 
   if (bad == 1) {
     mp_set(&cfg->modulus, 4);
   }
 
-  P_CHECKCB(msgpack_unpacker_init(&upk, 0));
-  P_CHECKCB(msgpack_unpacker_reserve_buffer(&upk, sbuf.size));
+  PT_CHECKCB(msgpack_unpacker_init(&upk, 0));
+  PT_CHECKCB(msgpack_unpacker_reserve_buffer(&upk, sbuf.size));
   memcpy(msgpack_unpacker_buffer(&upk), sbuf.data, sbuf.size);
   msgpack_unpacker_buffer_consumed(&upk, sbuf.size);
 

--- a/ptest/serial_test.c
+++ b/ptest/serial_test.c
@@ -11,12 +11,12 @@
 #include <string.h>
 
 #include "mutest.h"
-#include "test_util.h"
 #include "prio/client.h"
 #include "prio/config.h"
 #include "prio/serial.h"
 #include "prio/server.h"
 #include "prio/util.h"
+#include "test_util.h"
 
 SECStatus
 gen_client_packets(const_PrioConfig cfg, PrioPacketClient pA,

--- a/ptest/server_test.c
+++ b/ptest/server_test.c
@@ -10,10 +10,10 @@
 #include <mprio.h>
 
 #include "mutest.h"
-#include "test_util.h"
 #include "prio/client.h"
 #include "prio/server.c"
 #include "prio/server.h"
+#include "test_util.h"
 
 void
 mu_test__eval_poly(void)
@@ -76,7 +76,8 @@ mu_test__verify_new(void)
 
   PT_CHECKC(Keypair_new(&skA, &pkA));
   PT_CHECKC(Keypair_new(&skB, &pkB));
-  PT_CHECKA(cfg = PrioConfig_new(214, pkA, pkB, (unsigned char*)"testbatch", 9));
+  PT_CHECKA(cfg =
+              PrioConfig_new(214, pkA, pkB, (unsigned char*)"testbatch", 9));
 
   const int ndata = PrioConfig_numDataFields(cfg);
   PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));

--- a/ptest/server_test.c
+++ b/ptest/server_test.c
@@ -10,6 +10,7 @@
 #include <mprio.h>
 
 #include "mutest.h"
+#include "test_util.h"
 #include "prio/client.h"
 #include "prio/server.c"
 #include "prio/server.h"
@@ -25,15 +26,15 @@ mu_test__eval_poly(void)
   MP_DIGITS(&eval_at) = NULL;
   MP_DIGITS(&out) = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(54));
-  P_CHECKA(coeffs = MPArray_new(3));
+  PT_CHECKA(cfg = PrioConfig_newTest(54));
+  PT_CHECKA(coeffs = MPArray_new(3));
 
   mp_set(&coeffs->data[0], 2);
   mp_set(&coeffs->data[1], 8);
   mp_set(&coeffs->data[2], 3);
 
-  MP_CHECKC(mp_init(&eval_at));
-  MP_CHECKC(mp_init(&out));
+  MPT_CHECKC(mp_init(&eval_at));
+  MPT_CHECKC(mp_init(&out));
   mp_set(&eval_at, 7);
 
   const int val = 3 * 7 * 7 + 8 * 7 + 2;
@@ -71,48 +72,48 @@ mu_test__verify_new(void)
   MP_DIGITS(&hR) = NULL;
 
   PrioPRGSeed seed;
-  P_CHECKC(PrioPRGSeed_randomize(&seed));
+  PT_CHECKC(PrioPRGSeed_randomize(&seed));
 
-  P_CHECKC(Keypair_new(&skA, &pkA));
-  P_CHECKC(Keypair_new(&skB, &pkB));
-  P_CHECKA(cfg = PrioConfig_new(214, pkA, pkB, (unsigned char*)"testbatch", 9));
+  PT_CHECKC(Keypair_new(&skA, &pkA));
+  PT_CHECKC(Keypair_new(&skB, &pkB));
+  PT_CHECKA(cfg = PrioConfig_new(214, pkA, pkB, (unsigned char*)"testbatch", 9));
 
   const int ndata = PrioConfig_numDataFields(cfg);
-  P_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
   for (int i = 0; i < ndata; i++) {
     // Arbitrary data
     data_items[i] = (i % 3 == 1) || (i % 5 == 3);
   }
 
-  P_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
-  P_CHECKA(sB = PrioServer_new(cfg, 1, skB, seed));
+  PT_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
+  PT_CHECKA(sB = PrioServer_new(cfg, 1, skB, seed));
 
   unsigned int aLen, bLen;
-  P_CHECKC(PrioClient_encode(cfg, data_items, &for_a, &aLen, &for_b, &bLen));
+  PT_CHECKC(PrioClient_encode(cfg, data_items, &for_a, &aLen, &for_b, &bLen));
 
-  MP_CHECKC(mp_init(&fR));
-  MP_CHECKC(mp_init(&gR));
-  MP_CHECKC(mp_init(&hR));
+  MPT_CHECKC(mp_init(&fR));
+  MPT_CHECKC(mp_init(&gR));
+  MPT_CHECKC(mp_init(&hR));
 
-  P_CHECKA(vA = PrioVerifier_new(sA));
-  P_CHECKA(vB = PrioVerifier_new(sB));
-  P_CHECKC(PrioVerifier_set_data(vA, for_a, aLen));
-  P_CHECKC(PrioVerifier_set_data(vB, for_b, bLen));
+  PT_CHECKA(vA = PrioVerifier_new(sA));
+  PT_CHECKA(vB = PrioVerifier_new(sB));
+  PT_CHECKC(PrioVerifier_set_data(vA, for_a, aLen));
+  PT_CHECKC(PrioVerifier_set_data(vB, for_b, bLen));
 
   PrioPacketClient pA = vA->clientp;
   PrioPacketClient pB = vB->clientp;
-  MP_CHECKC(mp_addmod(&pA->f0_share, &pB->f0_share, &cfg->modulus, &fR));
-  MP_CHECKC(mp_addmod(&pA->g0_share, &pB->g0_share, &cfg->modulus, &gR));
-  MP_CHECKC(mp_addmod(&pA->h0_share, &pB->h0_share, &cfg->modulus, &hR));
+  MPT_CHECKC(mp_addmod(&pA->f0_share, &pB->f0_share, &cfg->modulus, &fR));
+  MPT_CHECKC(mp_addmod(&pA->g0_share, &pB->g0_share, &cfg->modulus, &gR));
+  MPT_CHECKC(mp_addmod(&pA->h0_share, &pB->h0_share, &cfg->modulus, &hR));
 
-  MP_CHECKC(mp_mulmod(&fR, &gR, &cfg->modulus, &fR));
+  MPT_CHECKC(mp_mulmod(&fR, &gR, &cfg->modulus, &fR));
   mu_check(mp_cmp(&fR, &hR) == 0);
 
-  MP_CHECKC(mp_addmod(&vA->share_fR, &vB->share_fR, &cfg->modulus, &fR));
-  MP_CHECKC(mp_addmod(&vA->share_gR, &vB->share_gR, &cfg->modulus, &gR));
-  MP_CHECKC(mp_addmod(&vA->share_hR, &vB->share_hR, &cfg->modulus, &hR));
+  MPT_CHECKC(mp_addmod(&vA->share_fR, &vB->share_fR, &cfg->modulus, &fR));
+  MPT_CHECKC(mp_addmod(&vA->share_gR, &vB->share_gR, &cfg->modulus, &gR));
+  MPT_CHECKC(mp_addmod(&vA->share_hR, &vB->share_hR, &cfg->modulus, &hR));
 
-  MP_CHECKC(mp_mulmod(&fR, &gR, &cfg->modulus, &fR));
+  MPT_CHECKC(mp_mulmod(&fR, &gR, &cfg->modulus, &fR));
   mu_check(mp_cmp(&fR, &hR) == 0);
 
 cleanup:
@@ -169,34 +170,34 @@ verify_full(int tweak)
   MP_DIGITS(&hR) = NULL;
 
   PrioPRGSeed seed;
-  P_CHECKC(PrioPRGSeed_randomize(&seed));
+  PT_CHECKC(PrioPRGSeed_randomize(&seed));
 
-  P_CHECKC(Keypair_new(&skA, &pkA));
-  P_CHECKC(Keypair_new(&skB, &pkB));
-  P_CHECKA(cfg = PrioConfig_new(47, pkA, pkB, (unsigned char*)"test4", 5));
+  PT_CHECKC(Keypair_new(&skA, &pkA));
+  PT_CHECKC(Keypair_new(&skB, &pkB));
+  PT_CHECKA(cfg = PrioConfig_new(47, pkA, pkB, (unsigned char*)"test4", 5));
 
   const int ndata = PrioConfig_numDataFields(cfg);
-  P_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
   for (int i = 0; i < ndata; i++) {
     // Arbitrary data
     data_items[i] = (i % 3 == 1) || (i % 5 == 3);
   }
 
-  P_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
-  P_CHECKA(sB = PrioServer_new(cfg, 1, skB, seed));
+  PT_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
+  PT_CHECKA(sB = PrioServer_new(cfg, 1, skB, seed));
 
   unsigned int aLen, bLen;
-  P_CHECKC(PrioClient_encode(cfg, data_items, &for_a, &aLen, &for_b, &bLen));
+  PT_CHECKC(PrioClient_encode(cfg, data_items, &for_a, &aLen, &for_b, &bLen));
 
   if (tweak == 5) {
     for_a[3] = 3;
     for_a[4] = 4;
   }
 
-  P_CHECKA(vA = PrioVerifier_new(sA));
-  P_CHECKA(vB = PrioVerifier_new(sB));
+  PT_CHECKA(vA = PrioVerifier_new(sA));
+  PT_CHECKA(vB = PrioVerifier_new(sB));
   P_CHECKC(PrioVerifier_set_data(vA, for_a, aLen));
-  P_CHECKC(PrioVerifier_set_data(vB, for_b, bLen));
+  PT_CHECKC(PrioVerifier_set_data(vB, for_b, bLen));
 
   if (tweak == 3) {
     mp_add_d(&vA->share_fR, 1, &vA->share_fR);
@@ -206,20 +207,20 @@ verify_full(int tweak)
     mp_add_d(&vB->share_gR, 1, &vB->share_gR);
   }
 
-  P_CHECKA(p1A = PrioPacketVerify1_new());
-  P_CHECKA(p1B = PrioPacketVerify1_new());
+  PT_CHECKA(p1A = PrioPacketVerify1_new());
+  PT_CHECKA(p1B = PrioPacketVerify1_new());
 
-  P_CHECKC(PrioPacketVerify1_set_data(p1A, vA));
-  P_CHECKC(PrioPacketVerify1_set_data(p1B, vB));
+  PT_CHECKC(PrioPacketVerify1_set_data(p1A, vA));
+  PT_CHECKC(PrioPacketVerify1_set_data(p1B, vB));
 
   if (tweak == 1) {
     mp_add_d(&p1B->share_d, 1, &p1B->share_d);
   }
 
-  P_CHECKA(p2A = PrioPacketVerify2_new());
-  P_CHECKA(p2B = PrioPacketVerify2_new());
-  P_CHECKC(PrioPacketVerify2_set_data(p2A, vA, p1A, p1B));
-  P_CHECKC(PrioPacketVerify2_set_data(p2B, vB, p1A, p1B));
+  PT_CHECKA(p2A = PrioPacketVerify2_new());
+  PT_CHECKA(p2B = PrioPacketVerify2_new());
+  PT_CHECKC(PrioPacketVerify2_set_data(p2A, vA, p1A, p1B));
+  PT_CHECKC(PrioPacketVerify2_set_data(p2B, vB, p1A, p1B));
 
   if (tweak == 2) {
     mp_add_d(&p2A->share_out, 1, &p2B->share_out);

--- a/ptest/share_test.c
+++ b/ptest/share_test.c
@@ -10,6 +10,7 @@
 #include <mprio.h>
 
 #include "mutest.h"
+#include "test_util.h"
 #include "prio/client.h"
 #include "prio/config.h"
 #include "prio/mparray.h"
@@ -28,15 +29,15 @@ mu_test_share(void)
   MP_DIGITS(&b) = NULL;
   MP_DIGITS(&c) = NULL;
 
-  P_CHECKA(cfg = PrioConfig_newTest(93));
-  P_CHECKA(t1 = BeaverTriple_new());
-  P_CHECKA(t2 = BeaverTriple_new());
+  PT_CHECKA(cfg = PrioConfig_newTest(93));
+  PT_CHECKA(t1 = BeaverTriple_new());
+  PT_CHECKA(t2 = BeaverTriple_new());
 
   mu_check(BeaverTriple_set_rand(cfg, t1, t2) == SECSuccess);
 
-  MP_CHECKC(mp_init(&a));
-  MP_CHECKC(mp_init(&b));
-  MP_CHECKC(mp_init(&c));
+  MPT_CHECKC(mp_init(&a));
+  MPT_CHECKC(mp_init(&b));
+  MPT_CHECKC(mp_init(&c));
 
   mu_check(mp_addmod(&t1->a, &t2->a, &cfg->modulus, &a) == MP_OKAY);
   mu_check(mp_addmod(&t1->b, &t2->b, &cfg->modulus, &b) == MP_OKAY);
@@ -61,25 +62,25 @@ mu_test_arr(void)
   SECStatus rv = SECSuccess;
   MPArray arr = NULL;
   MPArray arr2 = NULL;
-  P_CHECKA(arr = MPArray_new(10));
-  P_CHECKA(arr2 = MPArray_new(7));
+  PT_CHECKA(arr = MPArray_new(10));
+  PT_CHECKA(arr2 = MPArray_new(7));
 
   for (int i = 0; i < 10; i++) {
     mp_set(&arr->data[i], i);
   }
 
-  P_CHECKC(MPArray_resize(arr, 15));
+  PT_CHECKC(MPArray_resize(arr, 15));
   for (int i = 10; i < 15; i++) {
     mu_check(mp_cmp_d(&arr->data[i], 0) == 0);
     mp_set(&arr->data[i], i);
   }
 
-  P_CHECKC(MPArray_resize(arr, 7));
+  PT_CHECKC(MPArray_resize(arr, 7));
   for (int i = 10; i < 7; i++) {
     mu_check(mp_cmp_d(&arr->data[i], i) == 0);
   }
 
-  P_CHECKC(MPArray_copy(arr2, arr));
+  PT_CHECKC(MPArray_copy(arr2, arr));
   for (int i = 10; i < 7; i++) {
     mu_check(mp_cmp(&arr->data[i], &arr2->data[i]) == 0);
   }

--- a/ptest/share_test.c
+++ b/ptest/share_test.c
@@ -10,12 +10,12 @@
 #include <mprio.h>
 
 #include "mutest.h"
-#include "test_util.h"
 #include "prio/client.h"
 #include "prio/config.h"
 #include "prio/mparray.h"
 #include "prio/share.h"
 #include "prio/util.h"
+#include "test_util.h"
 
 void
 mu_test_share(void)

--- a/ptest/test_util.h
+++ b/ptest/test_util.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, Henry Corrigan-Gibbs
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef __TEST_UTIL_H__
+#define __TEST_UTIL_H__
+
+#include <mpi.h>
+#include <mprio.h>
+
+// These macros behave like the macros in "prio/util.h", except that they
+// also use `mu_check()` to check the return value of the argument. By
+// using these macros, you get a nice human-readable error message that
+// points to the line number where the test failed.
+
+#define PT_CHECKA(s)                                                           \
+  do {                                                                         \
+    bool v;                                                                    \
+    mu_check((v = (s)));                                                       \
+    if (!v) {                                                                  \
+      rv = SECFailure;                                                         \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0);
+
+#define PT_CHECKC(s)                                                           \
+  do {                                                                         \
+    mu_check((rv = (s)) == SECSuccess);                                        \
+    if (rv != SECSuccess) {                                                    \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0);
+
+#define PT_CHECKCB(s)                                                          \
+  do {                                                                         \
+    bool v;                                                                    \
+    mu_check((v = (s)));                                                       \
+    if (!v) {                                                                  \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0);
+
+#define MPT_CHECKC(s)                                                          \
+  do {                                                                         \
+    bool v;                                                                    \
+    mu_check((v = (s)) == MP_OKAY);                                            \
+    if (v != MP_OKAY) {                                                        \
+      rv = SECFailure;                                                         \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0);
+
+#endif /* __TEST_UTIL_H__ */


### PR DESCRIPTION
* This commit adds import/export functions for private keys to fix #48 .
* Also, while working on this, I realized that having the clang sanitizers on interferes with running valgrind, so I have a commit in here that allows turning the sanitizers on/off independently of `DEBUG` mode.