### PR TITLE
Update SConstruct to modify include path based on sys.platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,6 @@ For macOS using Homebrew:
 
     $ brew install nss nspr scons msgpack
 
-    $ export LINKFLAGS="-L/usr/local/opt/nss/lib"
-    $ export CPPFLAGS="-I/usr/local/opt/nss/include/nss -I/usr/local/opt/nspr/include/nspr"
-
 To compile the code, run:
 
     $ scons

--- a/SConstruct
+++ b/SConstruct
@@ -9,38 +9,50 @@ opts = Variables()
 opts.AddVariables(
     BoolVariable("DEBUG", "Make debug build", 0),
     BoolVariable("SANITIZE", "Use AddressSanitizer and UBSanitizer", 0),
-    BoolVariable("VERBOSE", "Show full build information", 0))
+    BoolVariable("VERBOSE", "Show full build information", 0),
+)
 
-env = Environment(options = opts,
-                  ENV = os.environ)
+env = Environment(options=opts, ENV=os.environ)
 
-env.Tool('clang')
+env.Tool("clang")
 
 # Add extra compiler flags from the environment
 for flag in ["CCFLAGS", "CFLAGS", "CPPFLAGS", "CXXFLAGS", "LINKFLAGS"]:
-  if flag in os.environ:
-    env.Append(**{flag: SCons.Util.CLVar(os.getenv(flag))})
+    if flag in os.environ:
+        env.Append(**{flag: SCons.Util.CLVar(os.getenv(flag))})
 
-if env["DEBUG"]: 
+if env["DEBUG"]:
     print("DEBUG MODE!")
-    env.Append(CCFLAGS = ["-g", "-DDEBUG"])
+    env.Append(CCFLAGS=["-g", "-DDEBUG"])
 
 if env["SANITIZE"]:
-    sanitizers = ['-fsanitize=address,undefined', \
-                  '-fno-sanitize-recover=undefined,integer,nullability']
-    env.Append(CCFLAGS = sanitizers, LINKFLAGS = sanitizers)
+    sanitizers = [
+        "-fsanitize=address,undefined",
+        "-fno-sanitize-recover=undefined,integer,nullability",
+    ]
+    env.Append(CCFLAGS=sanitizers, LINKFLAGS=sanitizers)
 
 env.Append(
-  LIBS = ["mprio", "mpi", "nss3", "nspr4"],
-  LIBPATH = ['#build/prio', "#build/mpi"],
-  CFLAGS = [ "-Wall", "-Werror", "-Wextra", "-O3", "-std=c99", "-Wvla",
-    "-I/usr/include/nspr", "-I/usr/include/nss", "-Impi", "-DDO_PR_CLEANUP"])
+    LIBS=["mprio", "mpi", "nss3", "nspr4"],
+    LIBPATH=["#build/prio", "#build/mpi"],
+    CFLAGS=[
+        "-Wall",
+        "-Werror",
+        "-Wextra",
+        "-O3",
+        "-std=c99",
+        "-Wvla",
+        "-I/usr/include/nspr",
+        "-I/usr/include/nss",
+        "-Impi",
+        "-DDO_PR_CLEANUP",
+    ],
+)
 
-env.Append(CPPPATH = ["#include", "#."])
-Export('env')
+env.Append(CPPPATH=["#include", "#."])
+Export("env")
 
-SConscript('mpi/SConscript', variant_dir='build/mpi')
-SConscript('pclient/SConscript', variant_dir='build/pclient')
-SConscript('prio/SConscript', variant_dir='build/prio')
-SConscript('ptest/SConscript', variant_dir='build/ptest')
-
+SConscript("mpi/SConscript", variant_dir="build/mpi")
+SConscript("pclient/SConscript", variant_dir="build/pclient")
+SConscript("prio/SConscript", variant_dir="build/prio")
+SConscript("ptest/SConscript", variant_dir="build/ptest")

--- a/SConstruct
+++ b/SConstruct
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+import sys
 import SCons
 
 opts = Variables()
@@ -32,6 +33,12 @@ if env["SANITIZE"]:
     ]
     env.Append(CCFLAGS=sanitizers, LINKFLAGS=sanitizers)
 
+if sys.platform == "darwin":
+    env.Append(LINKFLAGS=["-L/usr/local/opt/nss/lib"])
+    include_pattern = "-I/usr/local/opt/{0}/include/{0}"
+else:
+    include_pattern = "-I/usr/include/{0}"
+
 env.Append(
     LIBS=["mprio", "mpi", "nss3", "nspr4"],
     LIBPATH=["#build/prio", "#build/mpi"],
@@ -42,8 +49,8 @@ env.Append(
         "-O3",
         "-std=c99",
         "-Wvla",
-        "-I/usr/include/nspr",
-        "-I/usr/include/nss",
+        include_pattern.format("nss"),
+        include_pattern.format("nspr"),
         "-Impi",
         "-DDO_PR_CLEANUP",
     ],


### PR DESCRIPTION
This modifies the build script to include the right paths based on the current operating system (macOS or linux).