### PR TITLE
b-bit integer circuit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ addons:
     - scons
     - libmsgpack-dev
     - libnss3-dev
-    - clang-format-3.9
+    - clang-format-9
 
 script:
   - scons DEBUG=1 SANITIZE=1

--- a/include/mprio.h
+++ b/include/mprio.h
@@ -10,7 +10,8 @@
 #define __PRIO_H__
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <blapit.h>
@@ -22,7 +23,7 @@ extern "C" {
 
 /* Seed for a pseudo-random generator (PRG). */
 #define PRG_SEED_LENGTH AES_128_KEY_LENGTH
-typedef unsigned char PrioPRGSeed[PRG_SEED_LENGTH];
+  typedef unsigned char PrioPRGSeed[PRG_SEED_LENGTH];
 
 /* Length of a raw curve25519 public key, in bytes. */
 #define CURVE25519_KEY_LEN 32
@@ -30,272 +31,296 @@ typedef unsigned char PrioPRGSeed[PRG_SEED_LENGTH];
 /* Length of a hex-encoded curve25519 public key, in bytes. */
 #define CURVE25519_KEY_LEN_HEX 64
 
-/*
- * Type for each of the two servers.
- */
-typedef enum { PRIO_SERVER_A, PRIO_SERVER_B } PrioServerId;
+  /*
+   * Type for each of the two servers.
+   */
+  typedef enum
+  {
+    PRIO_SERVER_A,
+    PRIO_SERVER_B
+  } PrioServerId;
 
-/*
- * Opaque types
- */
-typedef struct prio_config* PrioConfig;
-typedef const struct prio_config* const_PrioConfig;
+  /*
+   * Opaque types
+   */
+  typedef struct prio_config* PrioConfig;
+  typedef const struct prio_config* const_PrioConfig;
 
-typedef struct prio_server* PrioServer;
-typedef const struct prio_server* const_PrioServer;
+  typedef struct prio_server* PrioServer;
+  typedef const struct prio_server* const_PrioServer;
 
-typedef struct prio_verifier* PrioVerifier;
-typedef const struct prio_verifier* const_PrioVerifier;
+  typedef struct prio_verifier* PrioVerifier;
+  typedef const struct prio_verifier* const_PrioVerifier;
 
-typedef struct prio_packet_verify1* PrioPacketVerify1;
-typedef const struct prio_packet_verify1* const_PrioPacketVerify1;
+  typedef struct prio_packet_verify1* PrioPacketVerify1;
+  typedef const struct prio_packet_verify1* const_PrioPacketVerify1;
 
-typedef struct prio_packet_verify2* PrioPacketVerify2;
-typedef const struct prio_packet_verify2* const_PrioPacketVerify2;
+  typedef struct prio_packet_verify2* PrioPacketVerify2;
+  typedef const struct prio_packet_verify2* const_PrioPacketVerify2;
 
-typedef struct prio_total_share* PrioTotalShare;
-typedef const struct prio_total_share* const_PrioTotalShare;
+  typedef struct prio_total_share* PrioTotalShare;
+  typedef const struct prio_total_share* const_PrioTotalShare;
 
-typedef SECKEYPublicKey* PublicKey;
-typedef const SECKEYPublicKey* const_PublicKey;
+  typedef SECKEYPublicKey* PublicKey;
+  typedef const SECKEYPublicKey* const_PublicKey;
 
-typedef SECKEYPrivateKey* PrivateKey;
-typedef const SECKEYPrivateKey* const_PrivateKey;
+  typedef SECKEYPrivateKey* PrivateKey;
+  typedef const SECKEYPrivateKey* const_PrivateKey;
 
-/*
- * Initialize and clear random number generator state.
- * You must call Prio_init() before using the library.
- * To avoid memory leaks, call Prio_clear() afterwards.
- */
-SECStatus Prio_init();
-void Prio_clear();
+  /*
+   * Initialize and clear random number generator state.
+   * You must call Prio_init() before using the library.
+   * To avoid memory leaks, call Prio_clear() afterwards.
+   */
+  SECStatus Prio_init();
+  void Prio_clear();
 
-/*
- * PrioConfig holds the system parameters. The two relevant things determined
- * by the config object are:
- *    (1) the number of data fields we are collecting, and
- *    (2) the modulus we use for modular arithmetic.
- * The default configuration uses an 87-bit modulus.
- *
- * The value `nFields` must be in the range `0 < nFields <= max`, where `max`
- * is the value returned by the function `PrioConfig_maxDataFields()` below.
- *
- * The `batch_id` field specifies which "batch" of aggregate statistics we are
- * computing. For example, if the aggregate statistics are computed every 24
- * hours, the `batch_id` might be set to an encoding of the date. The clients
- * and servers must all use the same `batch_id` for each run of the protocol.
- * Each set of aggregate statistics should use a different `batch_id`.
- *
- * `PrioConfig_new` does not keep a pointer to the `batch_id` string that the
- * caller passes in, so you may free the `batch_id` string as soon as
- * `PrioConfig_new` returns.
- */
-PrioConfig PrioConfig_new(int nFields, PublicKey serverA, PublicKey serverB,
-                          const unsigned char* batchId,
-                          unsigned int batchIdLen);
-void PrioConfig_clear(PrioConfig cfg);
-int PrioConfig_numDataFields(const_PrioConfig cfg);
+  /*
+   * PrioConfig holds the system parameters. The two relevant things determined
+   * by the config object are:
+   *    (1) the number of data fields we are collecting, and
+   *    (2) the modulus we use for modular arithmetic.
+   * The default configuration uses an 87-bit modulus.
+   *
+   * The value `nFields` must be in the range `0 < nFields <= max`, where `max`
+   * is the value returned by the function `PrioConfig_maxDataFields()` below.
+   *
+   * The `batch_id` field specifies which "batch" of aggregate statistics we are
+   * computing. For example, if the aggregate statistics are computed every 24
+   * hours, the `batch_id` might be set to an encoding of the date. The clients
+   * and servers must all use the same `batch_id` for each run of the protocol.
+   * Each set of aggregate statistics should use a different `batch_id`.
+   *
+   * `PrioConfig_new` does not keep a pointer to the `batch_id` string that the
+   * caller passes in, so you may free the `batch_id` string as soon as
+   * `PrioConfig_new` returns.
+   */
+  PrioConfig PrioConfig_new(int nFields,
+                            PublicKey serverA,
+                            PublicKey serverB,
+                            const unsigned char* batchId,
+                            unsigned int batchIdLen);
+  void PrioConfig_clear(PrioConfig cfg);
+  int PrioConfig_numDataFields(const_PrioConfig cfg);
 
-/*
- * Return the maximum number of data fields that the implementation supports.
- */
-int PrioConfig_maxDataFields(void);
+  /*
+   * Return the maximum number of data fields that the implementation supports.
+   */
+  int PrioConfig_maxDataFields(void);
 
-/*
- * Create a PrioConfig object with no encryption keys.  This routine is
- * useful for testing, but PrioClient_encode() will always fail when used with
- * this config.
- */
-PrioConfig PrioConfig_newTest(int nFields);
+  /*
+   * Create a PrioConfig object with no encryption keys.  This routine is
+   * useful for testing, but PrioClient_encode() will always fail when used with
+   * this config.
+   */
+  PrioConfig PrioConfig_newTest(int nFields);
 
-/*
- * We use the PublicKey and PrivateKey objects for public-key encryption. Each
- * Prio server has an associated public key, and the clients use these keys to
- * encrypt messages to the servers.
- */
-SECStatus Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey);
+  /*
+   * We use the PublicKey and PrivateKey objects for public-key encryption. Each
+   * Prio server has an associated public key, and the clients use these keys to
+   * encrypt messages to the servers.
+   */
+  SECStatus Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey);
 
-/*
- * Import a new curve25519 public/private key from the raw bytes given.  When
- * importing a private key, you must pass in the corresponding public key as
- * well. The byte arrays given as input should be of length
- * `CURVE25519_KEY_LEN`.
- *
- * These functions will allocate a new `PublicKey`/`PrivateKey` object, which
- * the caller must free using `PublicKey_clear`/`PrivateKey_clear`.
- */
-SECStatus PublicKey_import(PublicKey* pk, const unsigned char* data,
-                           unsigned int dataLen);
-SECStatus PrivateKey_import(PrivateKey* sk, const unsigned char* privData,
-                            unsigned int privDataLen,
-                            const unsigned char* pubData,
-                            unsigned int pubDataLen);
+  /*
+   * Import a new curve25519 public/private key from the raw bytes given.  When
+   * importing a private key, you must pass in the corresponding public key as
+   * well. The byte arrays given as input should be of length
+   * `CURVE25519_KEY_LEN`.
+   *
+   * These functions will allocate a new `PublicKey`/`PrivateKey` object, which
+   * the caller must free using `PublicKey_clear`/`PrivateKey_clear`.
+   */
+  SECStatus PublicKey_import(PublicKey* pk,
+                             const unsigned char* data,
+                             unsigned int dataLen);
+  SECStatus PrivateKey_import(PrivateKey* sk,
+                              const unsigned char* privData,
+                              unsigned int privDataLen,
+                              const unsigned char* pubData,
+                              unsigned int pubDataLen);
 
-/*
- * Import a new curve25519 public/private key from a hex string that contains
- * only the characters 0-9a-fA-F.
- *
- * The hex strings passed in must each be of length `CURVE25519_KEY_LEN_HEX`.
- * These functions will allocate a new `PublicKey`/`PrivateKey` object, which
- * the caller must free using `PublicKey_clear`/`PrivateKey_clear`.
- */
-SECStatus PublicKey_import_hex(PublicKey* pk, const unsigned char* hexData,
-                               unsigned int dataLen);
-SECStatus PrivateKey_import_hex(PrivateKey* sk,
-                                const unsigned char* privHexData,
-                                unsigned int privDataLen,
-                                const unsigned char* pubHexData,
-                                unsigned int pubDataLen);
+  /*
+   * Import a new curve25519 public/private key from a hex string that contains
+   * only the characters 0-9a-fA-F.
+   *
+   * The hex strings passed in must each be of length `CURVE25519_KEY_LEN_HEX`.
+   * These functions will allocate a new `PublicKey`/`PrivateKey` object, which
+   * the caller must free using `PublicKey_clear`/`PrivateKey_clear`.
+   */
+  SECStatus PublicKey_import_hex(PublicKey* pk,
+                                 const unsigned char* hexData,
+                                 unsigned int dataLen);
+  SECStatus PrivateKey_import_hex(PrivateKey* sk,
+                                  const unsigned char* privHexData,
+                                  unsigned int privDataLen,
+                                  const unsigned char* pubHexData,
+                                  unsigned int pubDataLen);
 
-/*
- * Export a curve25519 key as a raw byte-array.
- *
- * The output buffer `data` must have length exactly `CURVE25519_KEY_LEN`.
- */
-SECStatus PublicKey_export(const_PublicKey pk, unsigned char* data,
-                           unsigned int dataLen);
-SECStatus PrivateKey_export(PrivateKey sk, unsigned char* data,
-                            unsigned int dataLen);
+  /*
+   * Export a curve25519 key as a raw byte-array.
+   *
+   * The output buffer `data` must have length exactly `CURVE25519_KEY_LEN`.
+   */
+  SECStatus PublicKey_export(const_PublicKey pk,
+                             unsigned char* data,
+                             unsigned int dataLen);
+  SECStatus PrivateKey_export(PrivateKey sk,
+                              unsigned char* data,
+                              unsigned int dataLen);
 
-/*
- * Export a curve25519 key as a NULL-terminated hex string.
- *
- * The output buffer `data` must have length exactly `CURVE25519_KEY_LEN_HEX +
- * 1`.
- */
-SECStatus PublicKey_export_hex(const_PublicKey pk, unsigned char* data,
-                               unsigned int dataLen);
-SECStatus PrivateKey_export_hex(PrivateKey sk, unsigned char* data,
-                                unsigned int dataLen);
+  /*
+   * Export a curve25519 key as a NULL-terminated hex string.
+   *
+   * The output buffer `data` must have length exactly `CURVE25519_KEY_LEN_HEX +
+   * 1`.
+   */
+  SECStatus PublicKey_export_hex(const_PublicKey pk,
+                                 unsigned char* data,
+                                 unsigned int dataLen);
+  SECStatus PrivateKey_export_hex(PrivateKey sk,
+                                  unsigned char* data,
+                                  unsigned int dataLen);
 
-void PublicKey_clear(PublicKey pubkey);
-void PrivateKey_clear(PrivateKey pvtkey);
+  void PublicKey_clear(PublicKey pubkey);
+  void PrivateKey_clear(PrivateKey pvtkey);
 
-/*
- *  PrioPacketClient_encode
- *
- * Takes as input a pointer to an array (`data_in`) of boolean values
- * whose length is equal to the number of data fields specified in
- * the config. It then encodes the data for servers A and B into a
- * string.
- *
- * NOTE: The caller must free() the strings `for_server_a` and
- * `for_server_b` to avoid memory leaks.
- */
-SECStatus PrioClient_encode(const_PrioConfig cfg, const bool* data_in,
-                            unsigned char** forServerA, unsigned int* aLen,
-                            unsigned char** forServerB, unsigned int* bLen);
+  /*
+   *  PrioPacketClient_encode
+   *
+   * Takes as input a pointer to an array (`data_in`) of boolean values
+   * whose length is equal to the number of data fields specified in
+   * the config. It then encodes the data for servers A and B into a
+   * string.
+   *
+   * NOTE: The caller must free() the strings `for_server_a` and
+   * `for_server_b` to avoid memory leaks.
+   */
+  SECStatus PrioClient_encode(const_PrioConfig cfg,
+                              const bool* data_in,
+                              unsigned char** forServerA,
+                              unsigned int* aLen,
+                              unsigned char** forServerB,
+                              unsigned int* bLen);
 
-/*
- * Generate a new PRG seed using the NSS global randomness source.
- * Use this routine to initialize the secret that the two Prio servers
- * share.
- */
-SECStatus PrioPRGSeed_randomize(PrioPRGSeed* seed);
+  /*
+   * Generate a new PRG seed using the NSS global randomness source.
+   * Use this routine to initialize the secret that the two Prio servers
+   * share.
+   */
+  SECStatus PrioPRGSeed_randomize(PrioPRGSeed* seed);
 
-/*
- * The PrioServer object holds the state of the Prio servers.
- * Pass in the _same_ secret PRGSeed when initializing the two servers.
- * The PRGSeed must remain secret to the two servers.
- */
-PrioServer PrioServer_new(const_PrioConfig cfg, PrioServerId serverIdx,
-                          PrivateKey serverPriv,
-                          const PrioPRGSeed serverSharedSecret);
-void PrioServer_clear(PrioServer s);
+  /*
+   * The PrioServer object holds the state of the Prio servers.
+   * Pass in the _same_ secret PRGSeed when initializing the two servers.
+   * The PRGSeed must remain secret to the two servers.
+   */
+  PrioServer PrioServer_new(const_PrioConfig cfg,
+                            PrioServerId serverIdx,
+                            PrivateKey serverPriv,
+                            const PrioPRGSeed serverSharedSecret);
+  void PrioServer_clear(PrioServer s);
 
-/*
- * After receiving a client packet, each of the servers generate
- * a PrioVerifier object that they use to check whether the client's
- * encoded packet is well formed.
- */
-PrioVerifier PrioVerifier_new(PrioServer s);
-void PrioVerifier_clear(PrioVerifier v);
+  /*
+   * After receiving a client packet, each of the servers generate
+   * a PrioVerifier object that they use to check whether the client's
+   * encoded packet is well formed.
+   */
+  PrioVerifier PrioVerifier_new(PrioServer s);
+  void PrioVerifier_clear(PrioVerifier v);
 
-/*
- * Read in encrypted data from the client, decrypt it, and prepare to check the
- * request for validity.
- */
-SECStatus PrioVerifier_set_data(PrioVerifier v, unsigned char* data,
-                                unsigned int dataLen);
+  /*
+   * Read in encrypted data from the client, decrypt it, and prepare to check
+   * the request for validity.
+   */
+  SECStatus PrioVerifier_set_data(PrioVerifier v,
+                                  unsigned char* data,
+                                  unsigned int dataLen);
 
-/*
- * Generate the first packet that servers need to exchange to verify the
- * client's submission. This should be sent over a TLS connection between the
- * servers.
- */
-PrioPacketVerify1 PrioPacketVerify1_new(void);
-void PrioPacketVerify1_clear(PrioPacketVerify1 p1);
+  /*
+   * Generate the first packet that servers need to exchange to verify the
+   * client's submission. This should be sent over a TLS connection between the
+   * servers.
+   */
+  PrioPacketVerify1 PrioPacketVerify1_new(void);
+  void PrioPacketVerify1_clear(PrioPacketVerify1 p1);
 
-SECStatus PrioPacketVerify1_set_data(PrioPacketVerify1 p1,
-                                     const_PrioVerifier v);
+  SECStatus PrioPacketVerify1_set_data(PrioPacketVerify1 p1,
+                                       const_PrioVerifier v);
 
-SECStatus PrioPacketVerify1_write(const_PrioPacketVerify1 p,
-                                  msgpack_packer* pk);
-SECStatus PrioPacketVerify1_read(PrioPacketVerify1 p, msgpack_unpacker* upk,
-                                 const_PrioConfig cfg);
+  SECStatus PrioPacketVerify1_write(const_PrioPacketVerify1 p,
+                                    msgpack_packer* pk);
+  SECStatus PrioPacketVerify1_read(PrioPacketVerify1 p,
+                                   msgpack_unpacker* upk,
+                                   const_PrioConfig cfg);
 
-/*
- * Generate the second packet that the servers need to exchange to verify the
- * client's submission. The routine takes as input the PrioPacketVerify1
- * packets from both server A and server B.
- *
- * This should be sent over a TLS connection between the servers.
- */
-PrioPacketVerify2 PrioPacketVerify2_new(void);
-void PrioPacketVerify2_clear(PrioPacketVerify2 p);
+  /*
+   * Generate the second packet that the servers need to exchange to verify the
+   * client's submission. The routine takes as input the PrioPacketVerify1
+   * packets from both server A and server B.
+   *
+   * This should be sent over a TLS connection between the servers.
+   */
+  PrioPacketVerify2 PrioPacketVerify2_new(void);
+  void PrioPacketVerify2_clear(PrioPacketVerify2 p);
 
-SECStatus PrioPacketVerify2_set_data(PrioPacketVerify2 p2, const_PrioVerifier v,
-                                     const_PrioPacketVerify1 p1A,
-                                     const_PrioPacketVerify1 p1B);
+  SECStatus PrioPacketVerify2_set_data(PrioPacketVerify2 p2,
+                                       const_PrioVerifier v,
+                                       const_PrioPacketVerify1 p1A,
+                                       const_PrioPacketVerify1 p1B);
 
-SECStatus PrioPacketVerify2_write(const_PrioPacketVerify2 p,
-                                  msgpack_packer* pk);
-SECStatus PrioPacketVerify2_read(PrioPacketVerify2 p, msgpack_unpacker* upk,
-                                 const_PrioConfig cfg);
+  SECStatus PrioPacketVerify2_write(const_PrioPacketVerify2 p,
+                                    msgpack_packer* pk);
+  SECStatus PrioPacketVerify2_read(PrioPacketVerify2 p,
+                                   msgpack_unpacker* upk,
+                                   const_PrioConfig cfg);
 
-/*
- * Use the PrioPacketVerify2s from both servers to check whether
- * the client's submission is well formed.
- */
-SECStatus PrioVerifier_isValid(const_PrioVerifier v, const_PrioPacketVerify2 pA,
-                               const_PrioPacketVerify2 pB);
+  /*
+   * Use the PrioPacketVerify2s from both servers to check whether
+   * the client's submission is well formed.
+   */
+  SECStatus PrioVerifier_isValid(const_PrioVerifier v,
+                                 const_PrioPacketVerify2 pA,
+                                 const_PrioPacketVerify2 pB);
 
-/*
- * Each of the two servers calls this routine to aggregate the data
- * submission from a client that is included in the PrioVerifier object.
- *
- * IMPORTANT: This routine does *not* check the validity of the client's
- * data packet. The servers must execute the verification checks
- * above before aggregating any client data.
- */
-SECStatus PrioServer_aggregate(PrioServer s, PrioVerifier v);
+  /*
+   * Each of the two servers calls this routine to aggregate the data
+   * submission from a client that is included in the PrioVerifier object.
+   *
+   * IMPORTANT: This routine does *not* check the validity of the client's
+   * data packet. The servers must execute the verification checks
+   * above before aggregating any client data.
+   */
+  SECStatus PrioServer_aggregate(PrioServer s, PrioVerifier v);
 
-/*
- * After the servers have aggregated data packets from "enough" clients
- * (this determines the anonymity set size), each server runs this routine
- * to get a share of the aggregate statistics.
- */
-PrioTotalShare PrioTotalShare_new(void);
-void PrioTotalShare_clear(PrioTotalShare t);
+  /*
+   * After the servers have aggregated data packets from "enough" clients
+   * (this determines the anonymity set size), each server runs this routine
+   * to get a share of the aggregate statistics.
+   */
+  PrioTotalShare PrioTotalShare_new(void);
+  void PrioTotalShare_clear(PrioTotalShare t);
 
-SECStatus PrioTotalShare_set_data(PrioTotalShare t, const_PrioServer s);
+  SECStatus PrioTotalShare_set_data(PrioTotalShare t, const_PrioServer s);
 
-SECStatus PrioTotalShare_write(const_PrioTotalShare t, msgpack_packer* pk);
-SECStatus PrioTotalShare_read(PrioTotalShare t, msgpack_unpacker* upk,
-                              const_PrioConfig cfg);
+  SECStatus PrioTotalShare_write(const_PrioTotalShare t, msgpack_packer* pk);
+  SECStatus PrioTotalShare_read(PrioTotalShare t,
+                                msgpack_unpacker* upk,
+                                const_PrioConfig cfg);
 
-/*
- * Read the output data into an array of unsigned longs. You should
- * be sure that each data value can fit into a single `unsigned long`
- * and that the pointer `output` points to a buffer large enough to
- * store one long per data field.
- *
- * This function returns failure if some final data value is too
- * long to fit in an `unsigned long`.
- */
-SECStatus PrioTotalShare_final(const_PrioConfig cfg, unsigned long long* output,
-                               const_PrioTotalShare tA,
-                               const_PrioTotalShare tB);
+  /*
+   * Read the output data into an array of unsigned longs. You should
+   * be sure that each data value can fit into a single `unsigned long`
+   * and that the pointer `output` points to a buffer large enough to
+   * store one long per data field.
+   *
+   * This function returns failure if some final data value is too
+   * long to fit in an `unsigned long`.
+   */
+  SECStatus PrioTotalShare_final(const_PrioConfig cfg,
+                                 unsigned long long* output,
+                                 const_PrioTotalShare tA,
+                                 const_PrioTotalShare tB);
 
 #endif /* __PRIO_H__ */
 

--- a/include/mprio.h
+++ b/include/mprio.h
@@ -96,24 +96,26 @@ extern "C"
    * `PrioConfig_new` returns.
    */
   PrioConfig PrioConfig_new(int nFields,
+                            int precision,
                             PublicKey serverA,
                             PublicKey serverB,
                             const unsigned char* batchId,
                             unsigned int batchIdLen);
   void PrioConfig_clear(PrioConfig cfg);
   int PrioConfig_numDataFields(const_PrioConfig cfg);
+  int PrioConfig_precDataFields(const_PrioConfig cfg);
 
   /*
    * Return the maximum number of data fields that the implementation supports.
    */
-  int PrioConfig_maxDataFields(void);
+  int PrioConfig_maxDataFields(int precision);
 
   /*
    * Create a PrioConfig object with no encryption keys.  This routine is
    * useful for testing, but PrioClient_encode() will always fail when used with
    * this config.
    */
-  PrioConfig PrioConfig_newTest(int nFields);
+  PrioConfig PrioConfig_newTest(int nFields, int precision);
 
   /*
    * We use the PublicKey and PrivateKey objects for public-key encryption. Each
@@ -188,16 +190,17 @@ extern "C"
   /*
    *  PrioPacketClient_encode
    *
-   * Takes as input a pointer to an array (`data_in`) of boolean values
-   * whose length is equal to the number of data fields specified in
-   * the config. It then encodes the data for servers A and B into a
-   * string.
+   * Takes as input a pointer to an array (`data_in`) of long values,
+   * representable with at most b-bits, whose length is equal to the
+   * number of data fields specified in the config. It then encodes the
+   * data for servers A and B into a string.
    *
    * NOTE: The caller must free() the strings `for_server_a` and
    * `for_server_b` to avoid memory leaks.
+   * b is set in the config as "precision".
    */
   SECStatus PrioClient_encode(const_PrioConfig cfg,
-                              const bool* data_in,
+                              const long* data_in,
                               unsigned char** forServerA,
                               unsigned int* aLen,
                               unsigned char** forServerB,

--- a/pclient/main.c
+++ b/pclient/main.c
@@ -41,7 +41,7 @@ verify_full(void)
   const unsigned int batch_id_len = strlen((char*)batch_id);
 
   unsigned long long* output = NULL;
-  bool* data_items = NULL;
+  long* data_items = NULL;
 
   // Initialize NSS random number generator.
   P_CHECKC(Prio_init());
@@ -52,15 +52,22 @@ verify_full(void)
   // Number of clients to simulate.
   const int nclients = 10;
 
+  // Number of bits for each b-bit integerg
+  const int precision = 32;
+
+  // Maximum integer for given precision
+  const long max = (1l << (precision)) - 1;
+
   P_CHECKA(output = calloc(ndata, sizeof(unsigned long long)));
-  P_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  P_CHECKA(data_items = calloc(ndata, sizeof(long)));
 
   // Generate keypairs for servers
   P_CHECKC(Keypair_new(&skA, &pkA));
   P_CHECKC(Keypair_new(&skB, &pkB));
 
   // Use the default configuration parameters.
-  P_CHECKA(cfg = PrioConfig_new(ndata, pkA, pkB, batch_id, batch_id_len));
+  P_CHECKA(
+    cfg = PrioConfig_new(ndata, precision, pkA, pkB, batch_id, batch_id_len));
 
   PrioPRGSeed server_secret;
   P_CHECKC(PrioPRGSeed_randomize(&server_secret));
@@ -94,8 +101,8 @@ verify_full(void)
 
     // The client's data submission is an arbitrary boolean vector.
     for (int i = 0; i < ndata; i++) {
-      // Arbitrary data
-      data_items[i] = (i % 3 == 1) || (c % 5 == 3);
+      data_items[i] = max - i;
+      printf("data %d: %ld\n", i, data_items[i]);
     }
 
     // I. CLIENT DATA SUBMISSION.

--- a/pclient/main.c
+++ b/pclient/main.c
@@ -102,8 +102,8 @@ verify_full(void)
     //
     // Construct the client data packets.
     unsigned int aLen, bLen;
-    P_CHECKC(PrioClient_encode(cfg, data_items, &for_server_a, &aLen,
-                               &for_server_b, &bLen));
+    P_CHECKC(PrioClient_encode(
+      cfg, data_items, &for_server_a, &aLen, &for_server_b, &bLen));
 
     // The Prio servers A and B can come online later (e.g., at the end of
     // each day) to download the encrypted telemetry packets from the

--- a/prio/SConscript
+++ b/prio/SConscript
@@ -7,6 +7,8 @@ penv = env.Clone()
 src = [
     "client.c",
     "config.c",
+    "circuit.c",
+    "encode.c",
     "encrypt.c",
     "mparray.c",
     "poly.c",

--- a/prio/circuit.c
+++ b/prio/circuit.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020, Daniel Reusche
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <mpi.h>
+#include <mprio.h>
+
+#include "client.h"
+#include "config.h"
+#include "encode.h"
+#include "prg.h"
+#include "server.h"
+#include "util.h"
+
+SECStatus
+IntCircuit_set_fg_client(const_PrioConfig cfg,
+                         const_EIntArray data_in,
+                         MPArray points_f,
+                         MPArray points_g)
+{
+  SECStatus rv = SECSuccess;
+  const int num_data_fields = cfg->num_data_fields;
+  const int prec = cfg->precision;
+  const mp_int* mod = &cfg->modulus;
+  int pos;
+
+  for (int m = 0; m < num_data_fields; m++) {
+    // For each bit b_i, we compute b_i * (b_i-1)
+    for (int i = 0; i < prec; i++) {
+      pos = m + i;
+      // f(pos) = b_i
+      MP_CHECKC(
+        mp_copy(&data_in->data[m]->bits->data[i], &points_f->data[pos]));
+      MP_CHECKC(mp_mod(&points_f->data[pos], mod, &points_f->data[pos]));
+      // g(pos) = b_i - 1
+      MP_CHECKC(
+        mp_sub_d(&data_in->data[m]->bits->data[i], 1, &points_g->data[pos]));
+      MP_CHECKC(mp_mod(&points_g->data[pos], mod, &points_g->data[pos]));
+    }
+  }
+
+cleanup:
+  return rv;
+}
+
+SECStatus
+IntCircuit_set_fg_server(PrioVerifier v,
+                         const_EIntArray shares_in,
+                         MPArray points_f,
+                         MPArray points_g)
+{
+  SECStatus rv = SECSuccess;
+  const int num_data_fields = v->s->cfg->num_data_fields;
+  const int prec = v->s->cfg->precision;
+  const mp_int* mod = &v->s->cfg->modulus;
+  int pos;
+
+  for (int m = 0; m < num_data_fields; m++) {
+    // For each bit b_i, we compute b_i * (b_i-1)
+    for (int i = 0; i < prec; i++) {
+      // We offset pos by 1, since on the server f(0) and g(0) are already in
+      // place
+      pos = m + i + 1;
+      // [f](pos) = i-th data share
+      MP_CHECKC(
+        mp_copy(&shares_in->data[m]->bits->data[i], &points_f->data[pos]));
+      MP_CHECKC(mp_mod(&points_f->data[pos], mod, &points_f->data[pos]));
+      // [g](pos) = i-th data share minus 1
+      // Since subtraction is not distributive, we only do this on server 0
+      if (!v->s->idx) {
+        MP_CHECKC(mp_sub_d(
+          &shares_in->data[m]->bits->data[i], 1, &points_g->data[pos]));
+        MP_CHECKC(mp_mod(&points_g->data[pos], mod, &points_g->data[pos]));
+      }
+      // On server 1, we just copy the shares
+      if (v->s->idx) {
+        MP_CHECKC(
+          mp_copy(&shares_in->data[m]->bits->data[i], &points_g->data[pos]));
+      }
+    }
+  }
+
+cleanup:
+  return rv;
+}
+
+SECStatus
+IntCircuit_check_x_accum(const_PrioConfig cfg, const_EIntArray shares_in)
+{
+  SECStatus rv = SECSuccess;
+  const int num_data_fields = cfg->num_data_fields;
+  const int prec = cfg->precision;
+  const mp_int* mod = &cfg->modulus;
+
+  mp_int tmp;
+  mp_int accum;
+  MP_DIGITS(&tmp) = NULL;
+  MP_CHECKC(mp_init(&tmp));
+  MP_DIGITS(&accum) = NULL;
+  MP_CHECKC(mp_init(&accum));
+
+  for (int m = 0; m < num_data_fields; m++) {
+    mp_zero(&tmp);
+    mp_zero(&accum);
+    for (int i = 0; i < prec; i++) {
+      // count exponents down because of big-endianness
+      MP_CHECKC(mp_mul_d(
+        &shares_in->data[m]->bits->data[i], (1l << (prec - i - 1)), &tmp));
+      MP_CHECKC(mp_addmod(&tmp, &accum, mod, &accum));
+    }
+    MP_CHECKC(mp_cmp(&shares_in->data[m]->x, &accum));
+  }
+
+cleanup:
+  mp_clear(&tmp);
+  mp_clear(&accum);
+  return rv;
+}

--- a/prio/circuit.h
+++ b/prio/circuit.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, Daniel Reusche
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef __CIRCUIT_H__
+#define __CIRCUIT_H__
+
+#include "encode.h"
+#include "server.h"
+#include <mprio.h>
+
+/*
+ * For the b-bit integer circuit, the single bit circuit is used as a
+ * building block. The polynomials are set s.t. the bits of every
+ * EInt, serially, are the bits to be shared. For n EInts,
+ * this bitfield contains n*b bits.
+ *
+ * The x of every EInt contains an accumulation of the (shares of the)
+ * bits, to enable checking wether they correctly implement the (share
+ * of the) integer x. Since this is an affine transformation it is
+ * independent of the part of the circuit containing multiplication
+ * gates.
+ */
+
+/*
+ * Set points of f and g for client packages.
+ */
+SECStatus
+IntCircuit_set_fg_client(const_PrioConfig cfg,
+                         const_EIntArray data_in,
+                         MPArray points_f,
+                         MPArray points_g);
+
+/*
+ * Compute and set points of f and g shares for servers packages.
+ */
+SECStatus
+IntCircuit_set_fg_server(PrioVerifier v,
+                         const_EIntArray shares_in,
+                         MPArray points_f,
+                         MPArray points_g);
+
+/*
+ * Since this part of the circuit uses only affine transformations,
+ * each server can execute it on shares only.
+ */
+SECStatus
+IntCircuit_check_x_accum(const_PrioConfig cfg, const_EIntArray shares_in);
+
+#endif /* __CIRCUIT_H__ */

--- a/prio/client.c
+++ b/prio/client.c
@@ -29,8 +29,10 @@
 // and we return these evaluations as `evals_out`
 // and we return f(0) as `const_term`.
 static SECStatus
-data_polynomial_evals(const_PrioConfig cfg, const_MPArray data_in,
-                      MPArray evals_out, mp_int* const_term)
+data_polynomial_evals(const_PrioConfig cfg,
+                      const_MPArray data_in,
+                      MPArray evals_out,
+                      mp_int* const_term)
 {
   SECStatus rv = SECSuccess;
   const mp_int* mod = &cfg->modulus;
@@ -79,8 +81,11 @@ cleanup:
 }
 
 static SECStatus
-share_polynomials(const_PrioConfig cfg, const_MPArray data_in,
-                  PrioPacketClient pA, PrioPacketClient pB, PRG prgB)
+share_polynomials(const_PrioConfig cfg,
+                  const_MPArray data_in,
+                  PrioPacketClient pA,
+                  PrioPacketClient pB,
+                  PRG prgB)
 {
   SECStatus rv = SECSuccess;
   const mp_int* mod = &cfg->modulus;
@@ -199,8 +204,10 @@ cleanup:
 }
 
 SECStatus
-PrioPacketClient_set_data(const_PrioConfig cfg, const bool* data_in,
-                          PrioPacketClient pA, PrioPacketClient pB)
+PrioPacketClient_set_data(const_PrioConfig cfg,
+                          const bool* data_in,
+                          PrioPacketClient pA,
+                          PrioPacketClient pB)
 {
   MPArray client_data = NULL;
   PRG prgB = NULL;
@@ -277,9 +284,12 @@ PrioPacketClient_areEqual(const_PrioPacketClient p1, const_PrioPacketClient p2)
 }
 
 SECStatus
-PrioClient_encode(const_PrioConfig cfg, const bool* data_in,
-                  unsigned char** for_server_a, unsigned int* aLen,
-                  unsigned char** for_server_b, unsigned int* bLen)
+PrioClient_encode(const_PrioConfig cfg,
+                  const bool* data_in,
+                  unsigned char** for_server_a,
+                  unsigned int* aLen,
+                  unsigned char** for_server_b,
+                  unsigned int* bLen)
 {
   SECStatus rv = SECSuccess;
   PrioPacketClient pA = NULL;
@@ -310,10 +320,18 @@ PrioClient_encode(const_PrioConfig cfg, const bool* data_in,
 
   unsigned int writtenA;
   unsigned int writtenB;
-  P_CHECKC(PublicKey_encrypt(cfg->server_a_pub, *for_server_a, &writtenA, *aLen,
-                             (unsigned char*)sbufA.data, sbufA.size));
-  P_CHECKC(PublicKey_encrypt(cfg->server_b_pub, *for_server_b, &writtenB, *bLen,
-                             (unsigned char*)sbufB.data, sbufB.size));
+  P_CHECKC(PublicKey_encrypt(cfg->server_a_pub,
+                             *for_server_a,
+                             &writtenA,
+                             *aLen,
+                             (unsigned char*)sbufA.data,
+                             sbufA.size));
+  P_CHECKC(PublicKey_encrypt(cfg->server_b_pub,
+                             *for_server_b,
+                             &writtenB,
+                             *bLen,
+                             (unsigned char*)sbufB.data,
+                             sbufB.size));
 
   P_CHECKCB(writtenA == *aLen);
   P_CHECKCB(writtenB == *bLen);
@@ -337,8 +355,10 @@ cleanup:
 }
 
 SECStatus
-PrioPacketClient_decrypt(PrioPacketClient p, const_PrioConfig cfg,
-                         PrivateKey server_priv, const unsigned char* data_in,
+PrioPacketClient_decrypt(PrioPacketClient p,
+                         const_PrioConfig cfg,
+                         PrivateKey server_priv,
+                         const unsigned char* data_in,
                          unsigned int data_len)
 {
   SECStatus rv = SECSuccess;
@@ -351,7 +371,10 @@ PrioPacketClient_decrypt(PrioPacketClient p, const_PrioConfig cfg,
   unsigned int bytes_decrypted;
   P_CHECKC(PrivateKey_decrypt(server_priv,
                               (unsigned char*)msgpack_unpacker_buffer(&upk),
-                              &bytes_decrypted, data_len, data_in, data_len));
+                              &bytes_decrypted,
+                              data_len,
+                              data_in,
+                              data_len));
   msgpack_unpacker_buffer_consumed(&upk, bytes_decrypted);
 
   P_CHECKC(serial_read_packet_client(&upk, p, cfg));

--- a/prio/client.h
+++ b/prio/client.h
@@ -59,19 +59,24 @@ struct prio_packet_client
   } shares;
 };
 
-PrioPacketClient PrioPacketClient_new(const_PrioConfig cfg,
-                                      PrioServerId for_server);
-void PrioPacketClient_clear(PrioPacketClient p);
-SECStatus PrioPacketClient_set_data(const_PrioConfig cfg, const bool* data_in,
-                                    PrioPacketClient for_server_a,
-                                    PrioPacketClient for_server_b);
+PrioPacketClient
+PrioPacketClient_new(const_PrioConfig cfg, PrioServerId for_server);
+void
+PrioPacketClient_clear(PrioPacketClient p);
+SECStatus
+PrioPacketClient_set_data(const_PrioConfig cfg,
+                          const bool* data_in,
+                          PrioPacketClient for_server_a,
+                          PrioPacketClient for_server_b);
 
-SECStatus PrioPacketClient_decrypt(PrioPacketClient p, const_PrioConfig cfg,
-                                   PrivateKey server_priv,
-                                   const unsigned char* data_in,
-                                   unsigned int data_len);
+SECStatus
+PrioPacketClient_decrypt(PrioPacketClient p,
+                         const_PrioConfig cfg,
+                         PrivateKey server_priv,
+                         const unsigned char* data_in,
+                         unsigned int data_len);
 
-bool PrioPacketClient_areEqual(const_PrioPacketClient p1,
-                               const_PrioPacketClient p2);
+bool
+PrioPacketClient_areEqual(const_PrioPacketClient p1, const_PrioPacketClient p2);
 
 #endif /* __CLIENT_H__ */

--- a/prio/client.h
+++ b/prio/client.h
@@ -25,7 +25,7 @@ typedef const struct prio_packet_client* const_PrioPacketClient;
 struct server_a_data
 {
   // These values are only set for server A.
-  MPArray data_shares;
+  EIntArray data_shares;
   MPArray h_points;
 };
 
@@ -65,7 +65,7 @@ void
 PrioPacketClient_clear(PrioPacketClient p);
 SECStatus
 PrioPacketClient_set_data(const_PrioConfig cfg,
-                          const bool* data_in,
+                          const long* data_in,
                           PrioPacketClient for_server_a,
                           PrioPacketClient for_server_b);
 

--- a/prio/config.c
+++ b/prio/config.c
@@ -23,8 +23,11 @@ PrioConfig_maxDataFields(void)
 }
 
 PrioConfig
-PrioConfig_new(int n_fields, PublicKey server_a, PublicKey server_b,
-               const unsigned char* batch_id, unsigned int batch_id_len)
+PrioConfig_new(int n_fields,
+               PublicKey server_a,
+               PublicKey server_b,
+               const unsigned char* batch_id,
+               unsigned int batch_id_len)
 {
   SECStatus rv = SECSuccess;
   PrioConfig cfg = malloc(sizeof(*cfg));

--- a/prio/config.h
+++ b/prio/config.h
@@ -29,6 +29,7 @@ struct prio_config
   mp_int generator;
 };
 
-int PrioConfig_hPoints(const_PrioConfig cfg);
+int
+PrioConfig_hPoints(const_PrioConfig cfg);
 
 #endif /* __CONFIG_H__ */

--- a/prio/config.h
+++ b/prio/config.h
@@ -16,6 +16,7 @@
 struct prio_config
 {
   int num_data_fields;
+  int precision;
   unsigned char* batch_id;
   unsigned int batch_id_len;
 

--- a/prio/encode.c
+++ b/prio/encode.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2020, Daniel Reusche
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <mprio.h>
+#include <stdlib.h>
+
+#include "encode.h"
+#include "mparray.h"
+#include "util.h"
+
+EInt
+EInt_new(int prec)
+{
+  SECStatus rv = SECSuccess;
+
+  EInt e_int = malloc(sizeof *e_int);
+  if (!e_int)
+    return NULL;
+
+  e_int->prec = prec;
+
+  // initialize x
+  MP_DIGITS(&e_int->x) = NULL;
+  MP_CHECKC(mp_init(&e_int->x));
+
+  // create an MPArray to hold the bits
+  e_int->bits = NULL;
+  P_CHECKA(e_int->bits = MPArray_new(prec));
+
+cleanup:
+  if (rv != SECSuccess) {
+    EInt_clear(e_int);
+    return NULL;
+  }
+
+  return e_int;
+}
+
+SECStatus
+EInt_set(EInt dst, long x)
+{
+  SECStatus rv = SECSuccess;
+
+  int prec = dst->prec;
+  // maximum for b-bit encoding (b = precision)
+  long max = (1l << prec) - 1; // TODO: Compute maximum in PrioConfig?
+
+  P_CHECKCB(max >= x); // Check wether x is can be encoded with given precision
+  P_CHECKCB(0 <= x);   // Check wether x is non-negative
+  // set x
+  mp_set_int(&dst->x, x);
+
+  // The following block sets b_0, ..., b_(b-1)
+  // set b_0 (the first bit)
+  mp_set_int(&dst->bits->data[prec - 1], (x & 1));
+  // start with prec-2 to shift correctly
+  for (int bit = prec - 2; bit >= 0; bit--) {
+    // shift by one for subsequent bits (b_1, ..., b_(b-1))
+    (x >>= 1);
+    mp_set_int(&dst->bits->data[bit], (x & 1));
+    // from C99 on ">>" produces leading 0s since only unsigned ints are handled
+    // (see ISO/IEC 9899:1999, 6.5.7)
+  }
+
+cleanup:
+  return rv;
+}
+
+void
+EInt_clear(EInt e_int)
+{
+  if (e_int == NULL)
+    return;
+
+  if (e_int->bits != NULL)
+    MPArray_clear(e_int->bits);
+
+  mp_clear(&e_int->x);
+
+  free(e_int);
+}
+
+EIntArray
+EIntArray_new(int len, int prec)
+{
+  SECStatus rv = SECSuccess;
+  EIntArray arr = malloc(sizeof *arr);
+  if (!arr)
+    return NULL;
+
+  arr->data = NULL;
+  arr->len = len;
+  arr->prec = prec;
+
+  P_CHECKA(arr->data = calloc(len, sizeof(EInt_new(prec))));
+  for (int i = 0; i < len; i++) {
+    P_CHECKA(arr->data[i] = EInt_new(prec));
+  }
+
+cleanup:
+  if (rv != SECSuccess) {
+    EIntArray_clear(arr);
+    return NULL;
+  }
+
+  return arr;
+};
+
+EIntArray
+EIntArray_new_data(int len, int prec, const long* data_in)
+{
+  EIntArray arr = EIntArray_new(len, prec);
+  if (arr == NULL)
+    return NULL;
+
+  for (int i = 0; i < len; i++) {
+    EInt_set(arr->data[i], data_in[i]);
+  }
+
+  return arr;
+}
+
+void
+EIntArray_clear(EIntArray arr)
+{
+  if (arr == NULL)
+    return;
+
+  if (arr->data != NULL) {
+    for (int i = 0; i < arr->len; i++) {
+      EInt_clear(arr->data[i]);
+    }
+    free(arr->data);
+  }
+  free(arr);
+}
+
+SECStatus
+EIntArray_truncate_and_addmod(MPArray dst, EIntArray src, const mp_int* mod)
+{
+  if (src->len != dst->len)
+    return SECFailure;
+
+  for (int i = 0; i < dst->len; i++) {
+    MP_CHECK(mp_addmod(&dst->data[i], &src->data[i]->x, mod, &dst->data[i]));
+  }
+
+  return SECSuccess;
+}
+
+bool
+EInt_areEqual(const EInt n, const EInt m)
+{
+  if (n->prec != m->prec)
+    return false;
+
+  if (mp_cmp(&n->x, &m->x))
+    return false;
+
+  return (MPArray_areEqual(n->bits, m->bits));
+}
+
+bool
+EIntArray_areEqual(const_EIntArray arr1, const_EIntArray arr2)
+{
+  if (arr1->len != arr2->len)
+    return false;
+
+  for (int i = 0; i < arr1->len; i++) {
+    if (!(EInt_areEqual(arr1->data[i], arr2->data[i])))
+      return false;
+  }
+
+  return true;
+}

--- a/prio/encode.h
+++ b/prio/encode.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020, Daniel Reusche
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef __ENCODE_H__
+#define __ENCODE_H__
+
+#include "mparray.h"
+
+struct encoded_integer
+{
+  int prec;
+  mp_int x;
+  MPArray bits;
+};
+
+typedef struct encoded_integer* EInt;
+
+struct encoded_integer_array
+{
+  int len;
+  int prec;
+  EInt* data;
+};
+
+typedef struct encoded_integer_array* EIntArray;
+typedef const struct encoded_integer_array* const_EIntArray;
+
+/*
+ * Initialize an integer encoding of the given precision
+ */
+EInt
+EInt_new(int prec);
+void
+EInt_clear(EInt e_int);
+
+/*
+ * Write encoding for b-bit, long x to dst, with the following
+ * encoding:
+ * Enc(x) = (x, bit_0, bit_1, ..., bit_(b-1)), Big-endian
+ * b must be at most dst->prec
+ */
+SECStatus
+EInt_set(EInt dst, long x);
+
+/*
+ * Initialize an array of the given length, with `EInt`s of the given
+ * precision.
+ */
+EIntArray
+EIntArray_new(int len, int prec);
+void
+EIntArray_clear(EIntArray arr);
+
+/*
+ * Initialize array with unsigned int data given in data_in. Elements
+ * of data in must be encodeable with given precision.
+ */
+EIntArray
+EIntArray_new_data(int len, int prec, const long* data_in);
+
+/*
+ * Modular addition of x from src EInts to entries of dst.
+ */
+SECStatus
+EIntArray_truncate_and_addmod(MPArray dst, EIntArray src, const mp_int* mod);
+
+/*
+ * Return true iff the two encodings are equal.
+ * This comparison is NOT constant time.
+ */
+bool
+EInt_areEqual(const EInt arr1, const EInt arr2);
+
+/*
+ * Return true iff the two arrays are equal in length, precision and
+ * contents. This comparison is NOT constant time.
+ */
+bool
+EIntArray_areEqual(const_EIntArray arr1, const_EIntArray arr2);
+
+#endif /* __ENCODE_H__ */

--- a/prio/encrypt.c
+++ b/prio/encrypt.c
@@ -40,22 +40,117 @@ static const uint8_t curve25519_spki_zeros[] = {
 
 // The all-zeros curve25519 private key, as a PKCS#8 blob.
 static const uint8_t curve25519_priv_zeros[] = {
-  0x30, 0x67, 0x02, 0x01, 0x00, 0x30, 0x14, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce,
-  0x3d, 0x02, 0x01, 0x06, 0x09, 0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f,
-  0x01, 0x04, 0x4c, 0x30, 0x4a, 0x02, 0x01, 0x01, 0x04, 0x20,
+  0x30,
+  0x67,
+  0x02,
+  0x01,
+  0x00,
+  0x30,
+  0x14,
+  0x06,
+  0x07,
+  0x2a,
+  0x86,
+  0x48,
+  0xce,
+  0x3d,
+  0x02,
+  0x01,
+  0x06,
+  0x09,
+  0x2b,
+  0x06,
+  0x01,
+  0x04,
+  0x01,
+  0xda,
+  0x47,
+  0x0f,
+  0x01,
+  0x04,
+  0x4c,
+  0x30,
+  0x4a,
+  0x02,
+  0x01,
+  0x01,
+  0x04,
+  0x20,
 
   /* Byte index 36:  32 bytes of curve25519 private key. */
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
 
   /* misc type fields */
-  0xa1, 0x23, 0x03, 0x21,
+  0xa1,
+  0x23,
+  0x03,
+  0x21,
 
   /* Byte index 73:  32 bytes of curve25519 public key. */
-  0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+  0x00,
+  0x00,
+  0x04,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00
 };
 
 // Index into `curve25519_priv_zeros` at which the private key begins.
@@ -63,9 +158,9 @@ static const size_t curve25519_priv_sk_offset = 36;
 // Index into `curve25519_priv_zeros` at which the public key begins.
 static const size_t curve25519_priv_pk_offset = 73;
 
-static SECStatus key_from_hex(
-  unsigned char key_out[CURVE25519_KEY_LEN],
-  const unsigned char hex_in[CURVE25519_KEY_LEN_HEX]);
+static SECStatus
+key_from_hex(unsigned char key_out[CURVE25519_KEY_LEN],
+             const unsigned char hex_in[CURVE25519_KEY_LEN_HEX]);
 
 // Note that we do not use isxdigit because it is locale-dependent
 // See: https://github.com/mozilla/libprio/issues/20
@@ -113,9 +208,18 @@ derive_dh_secret(PK11SymKey** shared_secret, PrivateKey priv, PublicKey pub)
   SECStatus rv = SECSuccess;
   *shared_secret = NULL;
 
-  P_CHECKA(*shared_secret = PK11_PubDeriveWithKDF(
-             priv, pub, PR_FALSE, NULL, NULL, CKM_ECDH1_DERIVE, CKM_AES_GCM,
-             CKA_ENCRYPT | CKA_DECRYPT, 16, CKD_SHA256_KDF, NULL, NULL));
+  P_CHECKA(*shared_secret = PK11_PubDeriveWithKDF(priv,
+                                                  pub,
+                                                  PR_FALSE,
+                                                  NULL,
+                                                  NULL,
+                                                  CKM_ECDH1_DERIVE,
+                                                  CKM_AES_GCM,
+                                                  CKA_ENCRYPT | CKA_DECRYPT,
+                                                  16,
+                                                  CKD_SHA256_KDF,
+                                                  NULL,
+                                                  NULL));
 
 cleanup:
   return rv;
@@ -164,8 +268,10 @@ cleanup:
 }
 
 SECStatus
-PrivateKey_import(PrivateKey* sk, const unsigned char* sk_data,
-                  unsigned int sk_data_len, const unsigned char* pk_data,
+PrivateKey_import(PrivateKey* sk,
+                  const unsigned char* sk_data,
+                  unsigned int sk_data_len,
+                  const unsigned char* pk_data,
                   unsigned int pk_data_len)
 {
   if (sk_data_len != CURVE25519_KEY_LEN || !sk_data) {
@@ -211,7 +317,8 @@ cleanup:
 }
 
 SECStatus
-PublicKey_import_hex(PublicKey* pk, const unsigned char* hexData,
+PublicKey_import_hex(PublicKey* pk,
+                     const unsigned char* hexData,
                      unsigned int dataLen)
 {
   unsigned char raw_bytes[CURVE25519_KEY_LEN];
@@ -228,8 +335,10 @@ PublicKey_import_hex(PublicKey* pk, const unsigned char* hexData,
 }
 
 SECStatus
-PrivateKey_import_hex(PrivateKey* sk, const unsigned char* privHexData,
-                      unsigned int privDataLen, const unsigned char* pubHexData,
+PrivateKey_import_hex(PrivateKey* sk,
+                      const unsigned char* privHexData,
+                      unsigned int privDataLen,
+                      const unsigned char* pubHexData,
                       unsigned int pubDataLen)
 {
   SECStatus rv = SECSuccess;
@@ -248,8 +357,8 @@ PrivateKey_import_hex(PrivateKey* sk, const unsigned char* privHexData,
   P_CHECK(key_from_hex(raw_priv, privHexData));
   P_CHECK(key_from_hex(raw_pub, pubHexData));
 
-  return PrivateKey_import(sk, raw_priv, CURVE25519_KEY_LEN, raw_pub,
-                           CURVE25519_KEY_LEN);
+  return PrivateKey_import(
+    sk, raw_priv, CURVE25519_KEY_LEN, raw_pub, CURVE25519_KEY_LEN);
 }
 
 SECStatus
@@ -334,7 +443,8 @@ key_from_hex(unsigned char key_out[CURVE25519_KEY_LEN],
 }
 
 SECStatus
-PublicKey_export_hex(const_PublicKey pk, unsigned char* data,
+PublicKey_export_hex(const_PublicKey pk,
+                     unsigned char* data,
                      unsigned int dataLen)
 {
   if (dataLen != CURVE25519_KEY_LEN_HEX + 1) {
@@ -396,9 +506,13 @@ Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey)
   memcpy(&ecp.data[2], oid_data->oid.data, oid_data->oid.len);
 
   P_CHECKA(slot = PK11_GetInternalSlot());
-  P_CHECKA(*pvtkey = PK11_GenerateKeyPair(slot, CKM_EC_KEY_PAIR_GEN, &ecp,
-                                          (SECKEYPublicKey**)pubkey, PR_FALSE,
-                                          PR_FALSE, NULL));
+  P_CHECKA(*pvtkey = PK11_GenerateKeyPair(slot,
+                                          CKM_EC_KEY_PAIR_GEN,
+                                          &ecp,
+                                          (SECKEYPublicKey**)pubkey,
+                                          PR_FALSE,
+                                          PR_FALSE,
+                                          NULL));
 cleanup:
   if (slot) {
     PK11_FreeSlot(slot);
@@ -446,8 +560,11 @@ PublicKey_encryptSize(unsigned int inputLen, unsigned int* outputLen)
 }
 
 static void
-set_gcm_params(SECItem* paramItem, CK_GCM_PARAMS* param, unsigned char* nonce,
-               const_PublicKey pubkey, unsigned char* aadBuf)
+set_gcm_params(SECItem* paramItem,
+               CK_GCM_PARAMS* param,
+               unsigned char* nonce,
+               const_PublicKey pubkey,
+               unsigned char* aadBuf)
 {
   int offset = 0;
   memcpy(aadBuf, PRIO_TAG, strlen(PRIO_TAG));
@@ -468,9 +585,12 @@ set_gcm_params(SECItem* paramItem, CK_GCM_PARAMS* param, unsigned char* nonce,
 }
 
 SECStatus
-PublicKey_encrypt(PublicKey pubkey, unsigned char* output,
-                  unsigned int* outputLen, unsigned int maxOutputLen,
-                  const unsigned char* input, unsigned int inputLen)
+PublicKey_encrypt(PublicKey pubkey,
+                  unsigned char* output,
+                  unsigned int* outputLen,
+                  unsigned int maxOutputLen,
+                  const unsigned char* input,
+                  unsigned int inputLen)
 {
   if (pubkey == NULL)
     return SECFailure;
@@ -507,8 +627,14 @@ PublicKey_encrypt(PublicKey pubkey, unsigned char* output,
   memcpy(output + CURVE25519_KEY_LEN, param.pIv, param.ulIvLen);
 
   const int offset = CURVE25519_KEY_LEN + param.ulIvLen;
-  P_CHECKC(PK11_Encrypt(aes_key, CKM_AES_GCM, &paramItem, output + offset,
-                        outputLen, maxOutputLen - offset, input, inputLen));
+  P_CHECKC(PK11_Encrypt(aes_key,
+                        CKM_AES_GCM,
+                        &paramItem,
+                        output + offset,
+                        outputLen,
+                        maxOutputLen - offset,
+                        input,
+                        inputLen));
   *outputLen = *outputLen + CURVE25519_KEY_LEN + GCM_IV_LEN_BYTES;
 
 cleanup:
@@ -521,9 +647,12 @@ cleanup:
 }
 
 SECStatus
-PrivateKey_decrypt(PrivateKey privkey, unsigned char* output,
-                   unsigned int* outputLen, unsigned int maxOutputLen,
-                   const unsigned char* input, unsigned int inputLen)
+PrivateKey_decrypt(PrivateKey privkey,
+                   unsigned char* output,
+                   unsigned int* outputLen,
+                   unsigned int maxOutputLen,
+                   const unsigned char* input,
+                   unsigned int inputLen)
 {
   PK11SymKey* aes_key = NULL;
   PublicKey eph_pub = NULL;
@@ -555,8 +684,14 @@ PrivateKey_decrypt(PrivateKey privkey, unsigned char* output,
   P_CHECKC(derive_dh_secret(&aes_key, privkey, eph_pub));
 
   const int offset = CURVE25519_KEY_LEN + GCM_IV_LEN_BYTES;
-  P_CHECKC(PK11_Decrypt(aes_key, CKM_AES_GCM, &paramItem, output, outputLen,
-                        maxOutputLen, input + offset, inputLen - offset));
+  P_CHECKC(PK11_Decrypt(aes_key,
+                        CKM_AES_GCM,
+                        &paramItem,
+                        output,
+                        outputLen,
+                        maxOutputLen,
+                        input + offset,
+                        inputLen - offset));
 
 cleanup:
   PublicKey_clear(eph_pub);

--- a/prio/encrypt.h
+++ b/prio/encrypt.h
@@ -37,12 +37,14 @@
  * is too large (larger than `MAX_ENCRYPT_LEN`), this function returns
  * an error.
  */
-SECStatus PublicKey_encryptSize(unsigned int inputLen, unsigned int* outputLen);
+SECStatus
+PublicKey_encryptSize(unsigned int inputLen, unsigned int* outputLen);
 
 /*
  * Generate a new keypair for public-key encryption.
  */
-SECStatus Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey);
+SECStatus
+Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey);
 
 /*
  * Encrypt an arbitrary bitstring to the specified public key. The buffer
@@ -52,17 +54,25 @@ SECStatus Keypair_new(PrivateKey* pvtkey, PublicKey* pubkey);
  *
  * The value `inputLen` must be smaller than `MAX_ENCRYPT_LEN`.
  */
-SECStatus PublicKey_encrypt(PublicKey pubkey, unsigned char* output,
-                            unsigned int* outputLen, unsigned int maxOutputLen,
-                            const unsigned char* input, unsigned int inputLen);
+SECStatus
+PublicKey_encrypt(PublicKey pubkey,
+                  unsigned char* output,
+                  unsigned int* outputLen,
+                  unsigned int maxOutputLen,
+                  const unsigned char* input,
+                  unsigned int inputLen);
 
 /*
  * Decrypt an arbitrary bitstring using the specified private key.  The output
  * buffer should be at least 16 bytes larger than the plaintext you expect. If
  * `outputLen` >= `inputLen`, you should be safe.
  */
-SECStatus PrivateKey_decrypt(PrivateKey privkey, unsigned char* output,
-                             unsigned int* outputLen, unsigned int maxOutputLen,
-                             const unsigned char* input, unsigned int inputLen);
+SECStatus
+PrivateKey_decrypt(PrivateKey privkey,
+                   unsigned char* output,
+                   unsigned int* outputLen,
+                   unsigned int maxOutputLen,
+                   const unsigned char* input,
+                   unsigned int inputLen);
 
 #endif /* __ENCRYPT_H__ */

--- a/prio/mparray.c
+++ b/prio/mparray.c
@@ -139,7 +139,9 @@ MPArray_copy(MPArray dst, const_MPArray src)
 }
 
 SECStatus
-MPArray_set_share(MPArray arrA, MPArray arrB, const_MPArray src,
+MPArray_set_share(MPArray arrA,
+                  MPArray arrB,
+                  const_MPArray src,
                   const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;

--- a/prio/mparray.h
+++ b/prio/mparray.h
@@ -24,47 +24,58 @@ typedef const struct mparray* const_MPArray;
 /*
  * Initialize an array of `mp_int`s of the given length.
  */
-MPArray MPArray_new(int len);
-void MPArray_clear(MPArray arr);
+MPArray
+MPArray_new(int len);
+void
+MPArray_clear(MPArray arr);
 
 /*
  * Copies secret sharing of data from src into arrays
  * arrA and arrB. The lengths of the three input arrays
  * must be identical.
  */
-SECStatus MPArray_set_share(MPArray arrA, MPArray arrB, const_MPArray src,
-                            const_PrioConfig cfg);
+SECStatus
+MPArray_set_share(MPArray arrA,
+                  MPArray arrB,
+                  const_MPArray src,
+                  const_PrioConfig cfg);
 
 /*
  * Initializes array with 0/1 values specified in boolean array `data_in`
  */
-MPArray MPArray_new_bool(int len, const bool* data_in);
+MPArray
+MPArray_new_bool(int len, const bool* data_in);
 
 /*
  * Expands or shrinks the MPArray to the desired size. If shrinking,
  * will clear the values on the end of array.
  */
-SECStatus MPArray_resize(MPArray arr, int newlen);
+SECStatus
+MPArray_resize(MPArray arr, int newlen);
 
 /*
  * Initializes dst and creates a duplicate of the array in src.
  */
-MPArray MPArray_dup(const_MPArray src);
+MPArray
+MPArray_dup(const_MPArray src);
 
 /*
  * Copies array from src to dst. Arrays must have the same length.
  */
-SECStatus MPArray_copy(MPArray dst, const_MPArray src);
+SECStatus
+MPArray_copy(MPArray dst, const_MPArray src);
 
 /* For each index i into the array, set:
  *    dst[i] = dst[i] + to_add[i]   (modulo mod)
  */
-SECStatus MPArray_addmod(MPArray dst, const_MPArray to_add, const mp_int* mod);
+SECStatus
+MPArray_addmod(MPArray dst, const_MPArray to_add, const mp_int* mod);
 
 /*
  * Return true iff the two arrays are equal in length
  * and contents. This comparison is NOT constant time.
  */
-bool MPArray_areEqual(const_MPArray arr1, const_MPArray arr2);
+bool
+MPArray_areEqual(const_MPArray arr1, const_MPArray arr2);
 
 #endif /* __MPARRAY_H__ */

--- a/prio/poly.c
+++ b/prio/poly.c
@@ -24,8 +24,14 @@
  */
 
 static SECStatus
-fft_recurse(mp_int* out, const mp_int* mod, int n, const mp_int* roots,
-            const mp_int* ys, mp_int* tmp, mp_int* ySub, mp_int* rootsSub)
+fft_recurse(mp_int* out,
+            const mp_int* mod,
+            int n,
+            const mp_int* roots,
+            const mp_int* ys,
+            mp_int* tmp,
+            mp_int* ySub,
+            mp_int* rootsSub)
 {
   if (n == 1) {
     MP_CHECK(mp_copy(&ys[0], &out[0]));
@@ -38,8 +44,14 @@ fft_recurse(mp_int* out, const mp_int* mod, int n, const mp_int* roots,
     MP_CHECK(mp_copy(&roots[2 * i], &rootsSub[i]));
   }
 
-  MP_CHECK(fft_recurse(tmp, mod, n / 2, rootsSub, ySub, &tmp[n / 2],
-                       &ySub[n / 2], &rootsSub[n / 2]));
+  MP_CHECK(fft_recurse(tmp,
+                       mod,
+                       n / 2,
+                       rootsSub,
+                       ySub,
+                       &tmp[n / 2],
+                       &ySub[n / 2],
+                       &rootsSub[n / 2]));
   for (int i = 0; i < n / 2; i++) {
     MP_CHECK(mp_copy(&tmp[i], &out[2 * i]));
   }
@@ -50,8 +62,14 @@ fft_recurse(mp_int* out, const mp_int* mod, int n, const mp_int* roots,
     MP_CHECK(mp_mulmod(&ySub[i], &roots[i], mod, &ySub[i]));
   }
 
-  MP_CHECK(fft_recurse(tmp, mod, n / 2, rootsSub, ySub, &tmp[n / 2],
-                       &ySub[n / 2], &rootsSub[n / 2]));
+  MP_CHECK(fft_recurse(tmp,
+                       mod,
+                       n / 2,
+                       rootsSub,
+                       ySub,
+                       &tmp[n / 2],
+                       &ySub[n / 2],
+                       &rootsSub[n / 2]));
   for (int i = 0; i < n / 2; i++) {
     MP_CHECK(mp_copy(&tmp[i], &out[2 * i + 1]));
   }
@@ -60,8 +78,12 @@ fft_recurse(mp_int* out, const mp_int* mod, int n, const mp_int* roots,
 }
 
 static SECStatus
-fft_interpolate_raw(mp_int* out, const mp_int* ys, int nPoints,
-                    const_MPArray roots, const mp_int* mod, bool invert)
+fft_interpolate_raw(mp_int* out,
+                    const mp_int* ys,
+                    int nPoints,
+                    const_MPArray roots,
+                    const mp_int* mod,
+                    bool invert)
 {
   SECStatus rv = SECSuccess;
   MPArray tmp = NULL;
@@ -75,8 +97,8 @@ fft_interpolate_raw(mp_int* out, const mp_int* ys, int nPoints,
   mp_int n_inverse;
   MP_DIGITS(&n_inverse) = NULL;
 
-  MP_CHECKC(fft_recurse(out, mod, nPoints, roots->data, ys, tmp->data,
-                        ySub->data, rootsSub->data));
+  MP_CHECKC(fft_recurse(
+    out, mod, nPoints, roots->data, ys, tmp->data, ySub->data, rootsSub->data));
 
   if (invert) {
     MP_CHECKC(mp_init(&n_inverse));
@@ -104,7 +126,9 @@ cleanup:
  * of the n-th roots of unity.
  */
 SECStatus
-poly_fft_get_roots(MPArray roots_out, int n_points, const_PrioConfig cfg,
+poly_fft_get_roots(MPArray roots_out,
+                   int n_points,
+                   const_PrioConfig cfg,
                    bool invert)
 {
   if (n_points < 1) {
@@ -139,15 +163,17 @@ poly_fft_get_roots(MPArray roots_out, int n_points, const_PrioConfig cfg,
 
   for (int i = 2; i < n_points; i++) {
     // Compute g^i for all i in {0,..., n-1}
-    MP_CHECK(mp_mulmod(gen, &roots_out->data[i - 1], &cfg->modulus,
-                       &roots_out->data[i]));
+    MP_CHECK(mp_mulmod(
+      gen, &roots_out->data[i - 1], &cfg->modulus, &roots_out->data[i]));
   }
 
   return SECSuccess;
 }
 
 SECStatus
-poly_fft(MPArray points_out, const_MPArray points_in, const_PrioConfig cfg,
+poly_fft(MPArray points_out,
+         const_MPArray points_in,
+         const_PrioConfig cfg,
          bool invert)
 {
   SECStatus rv = SECSuccess;
@@ -164,8 +190,12 @@ poly_fft(MPArray points_out, const_MPArray points_in, const_PrioConfig cfg,
   P_CHECKA(scaled_roots = MPArray_new(n_points));
   P_CHECKC(poly_fft_get_roots(scaled_roots, n_points, cfg, invert));
 
-  P_CHECKC(fft_interpolate_raw(points_out->data, points_in->data, n_points,
-                               scaled_roots, &cfg->modulus, invert));
+  P_CHECKC(fft_interpolate_raw(points_out->data,
+                               points_in->data,
+                               n_points,
+                               scaled_roots,
+                               &cfg->modulus,
+                               invert));
 
 cleanup:
   MPArray_clear(scaled_roots);
@@ -174,7 +204,9 @@ cleanup:
 }
 
 SECStatus
-poly_eval(mp_int* value, const_MPArray coeffs, const mp_int* eval_at,
+poly_eval(mp_int* value,
+          const_MPArray coeffs,
+          const mp_int* eval_at,
           const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;
@@ -192,8 +224,10 @@ poly_eval(mp_int* value, const_MPArray coeffs, const mp_int* eval_at,
 }
 
 SECStatus
-poly_interp_evaluate(mp_int* value, const_MPArray poly_points,
-                     const mp_int* eval_at, const_PrioConfig cfg)
+poly_interp_evaluate(mp_int* value,
+                     const_MPArray poly_points,
+                     const mp_int* eval_at,
+                     const_PrioConfig cfg)
 {
   SECStatus rv;
   MPArray coeffs = NULL;

--- a/prio/poly.h
+++ b/prio/poly.h
@@ -21,8 +21,11 @@
  * of two and must be no longer than the number of precomputed
  * roots in the PrioConfig object passed in.
  */
-SECStatus poly_fft(MPArray points_out, const_MPArray points_in,
-                   const_PrioConfig cfg, bool invert);
+SECStatus
+poly_fft(MPArray points_out,
+         const_MPArray points_in,
+         const_PrioConfig cfg,
+         bool invert);
 
 /*
  * Get an array
@@ -33,15 +36,21 @@ SECStatus poly_fft(MPArray points_out, const_MPArray points_in,
  * Do NOT mp_clear() the mp_ints stored in roots_out.
  * These are owned by the PrioConfig object.
  */
-SECStatus poly_fft_get_roots(MPArray roots_out, int n_points,
-                             const_PrioConfig cfg, bool invert);
+SECStatus
+poly_fft_get_roots(MPArray roots_out,
+                   int n_points,
+                   const_PrioConfig cfg,
+                   bool invert);
 
 /*
  * Evaluate the polynomial specified by the coefficients
  * at the point `eval_at` and return the result as `value`.
  */
-SECStatus poly_eval(mp_int* value, const_MPArray coeffs, const mp_int* eval_at,
-                    const_PrioConfig cfg);
+SECStatus
+poly_eval(mp_int* value,
+          const_MPArray coeffs,
+          const mp_int* eval_at,
+          const_PrioConfig cfg);
 
 /*
  * Interpolate the polynomial through the points
@@ -50,7 +59,10 @@ SECStatus poly_eval(mp_int* value, const_MPArray coeffs, const mp_int* eval_at,
  * specified by `poly_points`. Evaluate the resulting polynomial
  * at the point `eval_at`. Return the result as `value`.
  */
-SECStatus poly_interp_evaluate(mp_int* value, const_MPArray poly_points,
-                               const mp_int* eval_at, const_PrioConfig cfg);
+SECStatus
+poly_interp_evaluate(mp_int* value,
+                     const_MPArray poly_points,
+                     const mp_int* eval_at,
+                     const_PrioConfig cfg);
 
 #endif

--- a/prio/prg.c
+++ b/prio/prg.c
@@ -55,11 +55,12 @@ PRG_new(const PrioPRGSeed key_in)
   CK_AES_CTR_PARAMS param = { 128, {} };
   SECItem paramItem = { siBuffer, (void*)&param, sizeof(CK_AES_CTR_PARAMS) };
 
-  P_CHECKA(prg->key = PK11_ImportSymKey(prg->slot, cipher, PK11_OriginUnwrap,
-                                        CKA_ENCRYPT, &keyItem, NULL));
+  P_CHECKA(
+    prg->key = PK11_ImportSymKey(
+      prg->slot, cipher, PK11_OriginUnwrap, CKA_ENCRYPT, &keyItem, NULL));
 
-  P_CHECKA(prg->ctx = PK11_CreateContextBySymKey(cipher, CKA_ENCRYPT, prg->key,
-                                                 &paramItem));
+  P_CHECKA(prg->ctx = PK11_CreateContextBySymKey(
+             cipher, CKA_ENCRYPT, prg->key, &paramItem));
 
 cleanup:
   if (rv != SECSuccess) {
@@ -94,7 +95,7 @@ PRG_get_bytes_internal(void* prg_vp, unsigned char* bytes, size_t len)
   unsigned char* in = NULL;
 
   P_CHECKA(in = calloc(len, sizeof(unsigned char)));
-  
+
   int outlen;
   P_CHECKC(PK11_CipherOp(prg->ctx, bytes, &outlen, len, in, len));
   P_CHECKCB((size_t)outlen == len);

--- a/prio/prg.h
+++ b/prio/prg.h
@@ -21,47 +21,55 @@ typedef const struct prg* const_PRG;
 /*
  * Initialize or destroy a pseudo-random generator.
  */
-PRG PRG_new(const PrioPRGSeed key);
-void PRG_clear(PRG prg);
+PRG
+PRG_new(const PrioPRGSeed key);
+void
+PRG_clear(PRG prg);
 
 /*
  * Produce the next bytes of output from the PRG.
  */
-SECStatus PRG_get_bytes(PRG prg, unsigned char* bytes, size_t len);
+SECStatus
+PRG_get_bytes(PRG prg, unsigned char* bytes, size_t len);
 
 /*
  * Use the PRG output to sample a big integer x in the range
  *    0 <= x < max.
  */
-SECStatus PRG_get_int(PRG prg, mp_int* out, const mp_int* max);
+SECStatus
+PRG_get_int(PRG prg, mp_int* out, const mp_int* max);
 
 /*
  * Use the PRG output to sample a big integer x in the range
  *    lower <= x < max.
  */
-SECStatus PRG_get_int_range(PRG prg, mp_int* out, const mp_int* lower,
-                            const mp_int* max);
+SECStatus
+PRG_get_int_range(PRG prg, mp_int* out, const mp_int* lower, const mp_int* max);
 
 /*
  * Use secret sharing to split the int src into two shares.
  * Use PRG to generate the value `shareB`.
  * The mp_ints must be initialized.
  */
-SECStatus PRG_share_int(PRG prg, mp_int* shareA, const mp_int* src,
-                        const_PrioConfig cfg);
+SECStatus
+PRG_share_int(PRG prg, mp_int* shareA, const mp_int* src, const_PrioConfig cfg);
 
 /*
  * Set each item in the array to a pseudorandom value in the range
  * [0, mod), where the values are generated using the PRG.
  */
-SECStatus PRG_get_array(PRG prg, MPArray arr, const mp_int* mod);
+SECStatus
+PRG_get_array(PRG prg, MPArray arr, const mp_int* mod);
 
 /*
  * Secret shares the array in `src` into `arrA` using randomness
  * provided by `prgB`. The arrays `src` and `arrA` must be the same
  * length.
  */
-SECStatus PRG_share_array(PRG prgB, MPArray arrA, const_MPArray src,
-                          const_PrioConfig cfg);
+SECStatus
+PRG_share_array(PRG prgB,
+                MPArray arrA,
+                const_MPArray src,
+                const_PrioConfig cfg);
 
 #endif /* __PRG_H__ */

--- a/prio/prg.h
+++ b/prio/prg.h
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 
 #include "config.h"
+#include "encode.h"
 
 typedef struct prg* PRG;
 typedef const struct prg* const_PRG;
@@ -40,6 +41,13 @@ SECStatus
 PRG_get_int(PRG prg, mp_int* out, const mp_int* max);
 
 /*
+ * Use the PRG output to sample a big encoded integer x in the range
+ *    0 <= x < max.
+ */
+SECStatus
+PRG_get_e_int(PRG prg, EInt out, const mp_int* max);
+
+/*
  * Use the PRG output to sample a big integer x in the range
  *    lower <= x < max.
  */
@@ -55,11 +63,37 @@ SECStatus
 PRG_share_int(PRG prg, mp_int* shareA, const mp_int* src, const_PrioConfig cfg);
 
 /*
+ * Compute a share of EInt src, with the share of x being derived from
+ * the shares of the individual bits. This way, checking wether a
+ * share of x is correctly encoded by the the sum of (b_i * 2^i), can
+ * be expressed as an affine transformation.
+ *
+ * With integer encoding, Enc(x) = (x, b_0, b_1, .. , b_(n-1)) the
+ * derivation works as follows:
+ *
+ * x = \sum_(i=0)^(n-1) 2^i * b_i)
+ *   => \sum_(i=0)^(n-1) ([b_i]_1 + [b_i]_2) * 2^i
+ *   => [x]_1 = \sum_(i=0)^(n-1) [b_i]_1 * 2^i,
+ *      [x]_2 = \sum_(i=0)^(n-1) [b_i]_2 * 2^i
+ *
+ * Thus: [x]_j - (\sum_(i=0)^(n-1) [b_i]_j * 2^i) = 0, with j={1,2}
+ */
+SECStatus
+PRG_share_e_int(PRG prgB, EInt shareA, EInt src, const_PrioConfig cfg);
+
+/*
  * Set each item in the array to a pseudorandom value in the range
  * [0, mod), where the values are generated using the PRG.
  */
 SECStatus
 PRG_get_array(PRG prg, MPArray arr, const mp_int* mod);
+
+/*
+ * Set each item in the array to a pseudorandom encoded value in the range
+ * [0, mod), where the values are generated using the PRG.
+ */
+SECStatus
+PRG_get_e_array(PRG prg, EIntArray dst, const mp_int* mod);
 
 /*
  * Secret shares the array in `src` into `arrA` using randomness
@@ -71,5 +105,16 @@ PRG_share_array(PRG prgB,
                 MPArray arrA,
                 const_MPArray src,
                 const_PrioConfig cfg);
+
+/*
+ * Secret shares the encoded array in `src` into `arrA` using randomness
+ * provided by `prgB`. The arrays `src` and `arrA` must be the same
+ * length.
+ */
+SECStatus
+PRG_share_e_array(PRG prgB,
+                  EIntArray arrA,
+                  const_EIntArray src,
+                  const_PrioConfig cfg);
 
 #endif /* __PRG_H__ */

--- a/prio/rand.c
+++ b/prio/rand.c
@@ -27,7 +27,11 @@ rand_init(void)
     return SECSuccess;
 
   prioGlobalContext =
-    NSS_InitContext("", "", "", "", NULL,
+    NSS_InitContext("",
+                    "",
+                    "",
+                    "",
+                    NULL,
                     NSS_INIT_READONLY | NSS_INIT_NOCERTDB | NSS_INIT_NOMODDB |
                       NSS_INIT_FORCEOPEN | NSS_INIT_NOROOTINIT);
 
@@ -76,7 +80,9 @@ rand_int(mp_int* out, const mp_int* max)
 }
 
 SECStatus
-rand_int_rng(mp_int* out, const mp_int* max, RandBytesFunc rng_func,
+rand_int_rng(mp_int* out,
+             const mp_int* max,
+             RandBytesFunc rng_func,
              void* user_data)
 {
   SECStatus rv = SECSuccess;

--- a/prio/rand.h
+++ b/prio/rand.h
@@ -17,28 +17,33 @@
  * Typedef for function pointer. A function pointer of type RandBytesFunc
  * points to a function that fills the buffer `out` of with `len` random bytes.
  */
-typedef SECStatus (*RandBytesFunc)(void* user_data, unsigned char* out,
+typedef SECStatus (*RandBytesFunc)(void* user_data,
+                                   unsigned char* out,
                                    size_t len);
 
 /*
  * Initialize or cleanup the global random number generator
  * state that NSS uses.
  */
-SECStatus rand_init(void);
-void rand_clear(void);
+SECStatus
+rand_init(void);
+void
+rand_clear(void);
 
 /*
  * Generate the specified number of random bytes using the
  * NSS random number generator.
  */
-SECStatus rand_bytes(unsigned char* out, size_t n_bytes);
+SECStatus
+rand_bytes(unsigned char* out, size_t n_bytes);
 
 /*
  * Generate a random number x such that
  *    0 <= x < max
  * using the NSS random number generator.
  */
-SECStatus rand_int(mp_int* out, const mp_int* max);
+SECStatus
+rand_int(mp_int* out, const mp_int* max);
 
 /*
  * Generate a random number x such that
@@ -48,7 +53,10 @@ SECStatus rand_int(mp_int* out, const mp_int* max);
  * The pointer user_data is passed to RandBytesFung `rng` as a first
  * argument.
  */
-SECStatus rand_int_rng(mp_int* out, const mp_int* max, RandBytesFunc rng,
-                       void* user_data);
+SECStatus
+rand_int_rng(mp_int* out,
+             const mp_int* max,
+             RandBytesFunc rng,
+             void* user_data);
 
 #endif /* __RAND_H__ */

--- a/prio/serial.c
+++ b/prio/serial.c
@@ -118,7 +118,9 @@ cleanup:
 }
 
 static SECStatus
-serial_read_mp_array(msgpack_unpacker* upk, MPArray arr, size_t len,
+serial_read_mp_array(msgpack_unpacker* upk,
+                     MPArray arr,
+                     size_t len,
                      const mp_int* max)
 {
   SECStatus rv = SECSuccess;
@@ -165,7 +167,8 @@ cleanup:
 }
 
 static SECStatus
-serial_read_beaver_triple(msgpack_unpacker* pk, BeaverTriple t,
+serial_read_beaver_triple(msgpack_unpacker* pk,
+                          BeaverTriple t,
                           const mp_int* max)
 {
   SECStatus rv = SECSuccess;
@@ -195,17 +198,18 @@ cleanup:
 }
 
 static SECStatus
-serial_read_server_a_data(msgpack_unpacker* upk, struct server_a_data* A,
+serial_read_server_a_data(msgpack_unpacker* upk,
+                          struct server_a_data* A,
                           const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;
   P_CHECKCB(upk != NULL);
   P_CHECKCB(A != NULL);
 
-  P_CHECKC(serial_read_mp_array(upk, A->data_shares, cfg->num_data_fields,
-                               &cfg->modulus));
-  P_CHECKC(serial_read_mp_array(upk, A->h_points, PrioConfig_hPoints(cfg),
-                               &cfg->modulus));
+  P_CHECKC(serial_read_mp_array(
+    upk, A->data_shares, cfg->num_data_fields, &cfg->modulus));
+  P_CHECKC(serial_read_mp_array(
+    upk, A->h_points, PrioConfig_hPoints(cfg), &cfg->modulus));
 
 cleanup:
   return rv;
@@ -276,7 +280,8 @@ cleanup:
 }
 
 SECStatus
-serial_write_packet_client(msgpack_packer* pk, const_PrioPacketClient p,
+serial_write_packet_client(msgpack_packer* pk,
+                           const_PrioPacketClient p,
                            const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;
@@ -326,7 +331,8 @@ cleanup:
 }
 
 SECStatus
-serial_read_packet_client(msgpack_unpacker* upk, PrioPacketClient p,
+serial_read_packet_client(msgpack_unpacker* upk,
+                          PrioPacketClient p,
                           const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;
@@ -388,7 +394,8 @@ cleanup:
 }
 
 SECStatus
-PrioPacketVerify1_read(PrioPacketVerify1 p, msgpack_unpacker* upk,
+PrioPacketVerify1_read(PrioPacketVerify1 p,
+                       msgpack_unpacker* upk,
                        const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;
@@ -416,7 +423,8 @@ cleanup:
 }
 
 SECStatus
-PrioPacketVerify2_read(PrioPacketVerify2 p, msgpack_unpacker* upk,
+PrioPacketVerify2_read(PrioPacketVerify2 p,
+                       msgpack_unpacker* upk,
                        const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;
@@ -443,15 +451,16 @@ cleanup:
 }
 
 SECStatus
-PrioTotalShare_read(PrioTotalShare t, msgpack_unpacker* upk,
+PrioTotalShare_read(PrioTotalShare t,
+                    msgpack_unpacker* upk,
                     const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;
   P_CHECKCB(t != NULL);
   P_CHECKCB(upk != NULL);
   P_CHECKC(serial_read_server_id(upk, &t->idx));
-  P_CHECKC(serial_read_mp_array(upk, t->data_shares, cfg->num_data_fields,
-                               &cfg->modulus));
+  P_CHECKC(serial_read_mp_array(
+    upk, t->data_shares, cfg->num_data_fields, &cfg->modulus));
 
 cleanup:
   return rv;

--- a/prio/serial.h
+++ b/prio/serial.h
@@ -11,11 +11,14 @@
 
 #include <mprio.h>
 
-SECStatus serial_write_packet_client(msgpack_packer* pk,
-                                     const_PrioPacketClient p,
-                                     const_PrioConfig cfg);
+SECStatus
+serial_write_packet_client(msgpack_packer* pk,
+                           const_PrioPacketClient p,
+                           const_PrioConfig cfg);
 
-SECStatus serial_read_packet_client(msgpack_unpacker* upk, PrioPacketClient p,
-                                    const_PrioConfig cfg);
+SECStatus
+serial_read_packet_client(msgpack_unpacker* upk,
+                          PrioPacketClient p,
+                          const_PrioConfig cfg);
 
 #endif /* __SERIAL_H__ */

--- a/prio/server.c
+++ b/prio/server.c
@@ -26,8 +26,10 @@
 #endif
 
 PrioServer
-PrioServer_new(const_PrioConfig cfg, PrioServerId server_idx,
-               PrivateKey server_priv, const PrioPRGSeed seed)
+PrioServer_new(const_PrioConfig cfg,
+               PrioServerId server_idx,
+               PrivateKey server_priv,
+               const PrioPRGSeed seed)
 {
   SECStatus rv = SECSuccess;
   PrioServer s = malloc(sizeof(*s));
@@ -119,8 +121,10 @@ PrioTotalShare_set_data(PrioTotalShare t, const_PrioServer s)
 }
 
 SECStatus
-PrioTotalShare_final(const_PrioConfig cfg, unsigned long long* output,
-                     const_PrioTotalShare tA, const_PrioTotalShare tB)
+PrioTotalShare_final(const_PrioConfig cfg,
+                     unsigned long long* output,
+                     const_PrioTotalShare tA,
+                     const_PrioTotalShare tB)
 {
   if (tA->data_shares->len != cfg->num_data_fields)
     return SECFailure;
@@ -136,8 +140,10 @@ PrioTotalShare_final(const_PrioConfig cfg, unsigned long long* output,
   MP_CHECKC(mp_init(&tmp));
 
   for (int i = 0; i < cfg->num_data_fields; i++) {
-    MP_CHECKC(mp_addmod(&tA->data_shares->data[i], &tB->data_shares->data[i],
-                        &cfg->modulus, &tmp));
+    MP_CHECKC(mp_addmod(&tA->data_shares->data[i],
+                        &tB->data_shares->data[i],
+                        &cfg->modulus,
+                        &tmp));
 
     if (MP_USED(&tmp) > 1) {
       P_CHECKCB(false);
@@ -292,13 +298,14 @@ cleanup:
 }
 
 SECStatus
-PrioVerifier_set_data(PrioVerifier v, unsigned char* data,
+PrioVerifier_set_data(PrioVerifier v,
+                      unsigned char* data,
                       unsigned int data_len)
 {
   SECStatus rv = SECSuccess;
   PRG prgB = NULL;
-  P_CHECKC(PrioPacketClient_decrypt(v->clientp, v->s->cfg, v->s->priv_key, data,
-                                    data_len));
+  P_CHECKC(PrioPacketClient_decrypt(
+    v->clientp, v->s->cfg, v->s->priv_key, data, data_len));
 
   PrioPacketClient p = v->clientp;
   if (p->for_server != v->s->idx)
@@ -428,7 +435,8 @@ PrioPacketVerify2_clear(PrioPacketVerify2 p)
 }
 
 SECStatus
-PrioPacketVerify2_set_data(PrioPacketVerify2 p2, const_PrioVerifier v,
+PrioPacketVerify2_set_data(PrioPacketVerify2 p2,
+                           const_PrioVerifier v,
                            const_PrioPacketVerify1 p1A,
                            const_PrioPacketVerify1 p1B)
 {
@@ -486,7 +494,8 @@ cleanup:
 }
 
 int
-PrioVerifier_isValid(const_PrioVerifier v, const_PrioPacketVerify2 pA,
+PrioVerifier_isValid(const_PrioVerifier v,
+                     const_PrioPacketVerify2 pA,
                      const_PrioPacketVerify2 pB)
 {
   SECStatus rv = SECSuccess;

--- a/prio/server.h
+++ b/prio/server.h
@@ -9,6 +9,7 @@
 #ifndef __SERVER_H__
 #define __SERVER_H__
 
+#include "client.h"
 #include "mparray.h"
 #include "prg.h"
 #include "share.h"
@@ -41,7 +42,7 @@ struct prio_verifier
   PrioServer s;
 
   PrioPacketClient clientp;
-  MPArray data_sharesB;
+  EIntArray data_sharesB;
   MPArray h_pointsB;
 
   mp_int share_fR;

--- a/prio/share.c
+++ b/prio/share.c
@@ -13,7 +13,9 @@
 #include "util.h"
 
 SECStatus
-share_int(const struct prio_config* cfg, const mp_int* src, mp_int* shareA,
+share_int(const struct prio_config* cfg,
+          const mp_int* src,
+          mp_int* shareA,
           mp_int* shareB)
 {
   SECStatus rv;

--- a/prio/share.h
+++ b/prio/share.h
@@ -27,8 +27,11 @@ typedef const struct beaver_triple* const_BeaverTriple;
  * Use secret sharing to split the int src into two shares.
  * The mp_ints must be initialized.
  */
-SECStatus share_int(const_PrioConfig cfg, const mp_int* src, mp_int* shareA,
-                    mp_int* shareB);
+SECStatus
+share_int(const_PrioConfig cfg,
+          const mp_int* src,
+          mp_int* shareA,
+          mp_int* shareB);
 
 /*
  * Prio uses Beaver triples to implement one step of the
@@ -36,12 +39,17 @@ SECStatus share_int(const_PrioConfig cfg, const mp_int* src, mp_int* shareA,
  * a sharing of random values a, b, c such that
  *    a * b = c
  */
-BeaverTriple BeaverTriple_new(void);
-void BeaverTriple_clear(BeaverTriple t);
+BeaverTriple
+BeaverTriple_new(void);
+void
+BeaverTriple_clear(BeaverTriple t);
 
-SECStatus BeaverTriple_set_rand(const_PrioConfig cfg, BeaverTriple triple_a,
-                                BeaverTriple triple_b);
+SECStatus
+BeaverTriple_set_rand(const_PrioConfig cfg,
+                      BeaverTriple triple_a,
+                      BeaverTriple triple_b);
 
-bool BeaverTriple_areEqual(const_BeaverTriple t1, const_BeaverTriple t2);
+bool
+BeaverTriple_areEqual(const_BeaverTriple t1, const_BeaverTriple t2);
 
 #endif /* __SHARE_H__ */

--- a/prio/util.h
+++ b/prio/util.h
@@ -9,6 +9,7 @@
 #ifndef __UTIL_H__
 #define __UTIL_H__
 
+#include "params.h"
 #include <mpi.h>
 #include <mprio.h>
 

--- a/ptest/SConscript
+++ b/ptest/SConscript
@@ -7,7 +7,9 @@ prio_env = env.Clone()
 test_srcs = [
     "mutest.c",
     "client_test.c",
+    "circuit_test.c",
     "example_test.c",
+    "encode_test.c",
     "encrypt_test.c",
     "fft_test.c",
     "mpi_test.c",
@@ -41,4 +43,3 @@ prio_env.Install("mutest.h")
 test_objs = prio_env.Object(test_srcs)
 test_main = prio_env.MkMutest(test_objs)
 prio_env.Program("ptest", [test_main] + test_objs)
-

--- a/ptest/circuit_test.c
+++ b/ptest/circuit_test.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2020, Daniel Reusche
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <mpi.h>
+#include <mprio.h>
+
+#include "mutest.h"
+#include "prio/circuit.c"
+#include "prio/circuit.h"
+#include "prio/encode.c"
+#include "prio/encode.h"
+#include "prio/prg.h"
+
+#include "test_util.h"
+
+/*
+ * IntCircuit_set_fg_client and IntCircuit_set_fg_server get tested in
+ * client_test and server_test respectively, like in the single bit
+ * case.
+ */
+
+/*
+ * Produce EInt shares where the bit shares do not implement the share of x
+ */
+SECStatus
+forged_shared_EInt(const_PrioConfig cfg, PRG prg, int x, EInt out)
+{
+  SECStatus rv = SECSuccess;
+
+  int prec = cfg->precision;
+
+  mp_int forge;
+  EInt src = NULL;
+
+  MP_DIGITS(&forge) = NULL;
+  MPT_CHECKC(mp_init(&forge));
+  mp_set_int(&forge, x + 1);
+
+  PT_CHECKA(src = EInt_new(prec));
+  P_CHECKC(EInt_set(src, x)); // Not PT_CHECKC since test would fail to early
+  PT_CHECKC(PRG_share_e_int(prg, out, src, cfg));
+
+  // Write the share of forge to x of share
+  PT_CHECKC(PRG_share_int(prg, &out->x, &forge, cfg));
+
+cleanup:
+  mp_clear(&forge);
+  EInt_clear(src);
+  return rv;
+}
+
+/*
+ * Test wether IntCircuit_check_x_accum recognizes EInt with
+ * non-matching x and bits
+ */
+void
+test__bad_EInt(int tweak)
+{
+  SECStatus rv = SECSuccess;
+  PrioConfig cfg = NULL;
+
+  int fields = 10;
+  int prec = 32;
+  long max = (1l << (prec)) - 1;
+
+  long* longs = NULL;
+
+  PrioPRGSeed key;
+  PRG prg = NULL;
+
+  EIntArray data_in = NULL;
+  EIntArray shares = NULL;
+
+  PT_CHECKA(cfg = PrioConfig_newTest(fields, prec));
+
+  PT_CHECKC(PrioPRGSeed_randomize(&key));
+  PT_CHECKA(prg = PRG_new(key));
+
+  P_CHECKA(longs = calloc(fields, sizeof(long)));
+
+  for (int i = 0; i < fields; i++) {
+    longs[i] = max - i;
+  }
+
+  PT_CHECKA(data_in = EIntArray_new_data(fields, prec, longs));
+  PT_CHECKA(shares = EIntArray_new(fields, prec));
+  PT_CHECKC(PRG_share_e_array(prg, shares, data_in, cfg));
+
+  // Introduce one EInt with bit shares not matching x
+  if (tweak == 1) {
+    P_CHECKC(forged_shared_EInt(cfg, prg, longs[0], shares->data[0]));
+  }
+
+  // Only EInts with bit shares not matching x
+  if (tweak == 2) {
+    for (int i = 0; i < fields; i++) {
+      P_CHECKC(forged_shared_EInt(cfg, prg, longs[i], shares->data[i]));
+    }
+  }
+
+  P_CHECKC(IntCircuit_check_x_accum(cfg, shares));
+
+cleanup:
+  if (tweak == 0) {
+    mu_check(rv == SECSuccess);
+  }
+  if (tweak != 0) {
+    mu_check(rv == SECFailure);
+  }
+  if (longs)
+    free(longs);
+  PRG_clear(prg);
+  EIntArray_clear(data_in);
+  EIntArray_clear(shares);
+  PrioConfig_clear(cfg);
+}
+
+// No bad EInts
+void
+mu_test__check_bad_EInt_good(void)
+{
+  test__bad_EInt(0);
+}
+
+// One bad EInt
+void
+mu_test__check_bad_EInt_bad1(void)
+{
+  test__bad_EInt(1);
+}
+
+// Only bad EInts
+void
+mu_test__check_bad_EInt_bad2(void)
+{
+  test__bad_EInt(2);
+}

--- a/ptest/client_test.c
+++ b/ptest/client_test.c
@@ -21,18 +21,19 @@ mu_test_client__new(void)
   PrioConfig cfg = NULL;
   PrioPacketClient pA = NULL;
   PrioPacketClient pB = NULL;
-  bool* data_items = NULL;
+  long* data_items = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(23));
+  PT_CHECKA(cfg = PrioConfig_newTest(23, 1));
   PT_CHECKA(pA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
   PT_CHECKA(pB = PrioPacketClient_new(cfg, PRIO_SERVER_B));
 
   const int ndata = PrioConfig_numDataFields(cfg);
-  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  const int prec = PrioConfig_precDataFields(cfg);
+  long max = (1l << (prec)) - 1;
 
+  PT_CHECKA(data_items = calloc(ndata, sizeof(long)));
   for (int i = 0; i < ndata; i++) {
-    // Arbitrary data
-    data_items[i] = (i % 3 == 1) || (i % 5 == 3);
+    data_items[i] = max - i;
   }
 
   PT_CHECKC(PrioPacketClient_set_data(cfg, data_items, pA, pB));
@@ -48,7 +49,7 @@ cleanup:
 }
 
 void
-test_client_agg(int nclients, int nfields, bool config_is_okay)
+test_client_agg(int nclients, int nfields, int precision, bool config_is_okay)
 {
   SECStatus rv = SECSuccess;
   PublicKey pkA = NULL;
@@ -66,7 +67,7 @@ test_client_agg(int nclients, int nfields, bool config_is_okay)
   unsigned char* for_b = NULL;
   const unsigned char* batch_id = (unsigned char*)"test_batch";
   unsigned int batch_id_len = strlen((char*)batch_id);
-  bool* data_items = NULL;
+  long* data_items = NULL;
   unsigned long long* output = NULL;
 
   PrioPRGSeed seed;
@@ -74,10 +75,12 @@ test_client_agg(int nclients, int nfields, bool config_is_okay)
 
   PT_CHECKC(Keypair_new(&skA, &pkA));
   PT_CHECKC(Keypair_new(&skB, &pkB));
-  P_CHECKA(cfg = PrioConfig_new(nfields, pkA, pkB, batch_id, batch_id_len));
+  P_CHECKA(
+    cfg = PrioConfig_new(nfields, precision, pkA, pkB, batch_id, batch_id_len));
   if (!config_is_okay) {
     PT_CHECKCB(
-      (PrioConfig_new(nfields, pkA, pkB, batch_id, batch_id_len) == NULL));
+      (PrioConfig_new(nfields, precision, pkA, pkB, batch_id, batch_id_len) ==
+       NULL));
   }
   PT_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
   PT_CHECKA(sB = PrioServer_new(cfg, 1, skB, seed));
@@ -87,11 +90,12 @@ test_client_agg(int nclients, int nfields, bool config_is_okay)
   PT_CHECKA(vB = PrioVerifier_new(sB));
 
   const int ndata = PrioConfig_numDataFields(cfg);
+  const int prec = PrioConfig_precDataFields(cfg);
+  long max = (1l << (prec)) - 1;
 
-  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  PT_CHECKA(data_items = calloc(ndata, sizeof(long)));
   for (int i = 0; i < ndata; i++) {
-    // Arbitrary data
-    data_items[i] = (i % 3 == 1) || (i % 5 == 3);
+    data_items[i] = max - i;
   }
 
   for (int i = 0; i < nclients; i++) {
@@ -114,10 +118,10 @@ test_client_agg(int nclients, int nfields, bool config_is_okay)
   mu_check(PrioTotalShare_set_data(tA, sA) == SECSuccess);
   mu_check(PrioTotalShare_set_data(tB, sB) == SECSuccess);
 
-  PT_CHECKA(output = calloc(ndata, sizeof(unsigned long)));
+  PT_CHECKA(output = calloc(ndata, sizeof(unsigned long long)));
   mu_check(PrioTotalShare_final(cfg, output, tA, tB) == SECSuccess);
   for (int i = 0; i < ndata; i++) {
-    unsigned long v = ((i % 3 == 1) || (i % 5 == 3));
+    unsigned long v = max - i;
     mu_check(output[i] == v * nclients);
   }
 
@@ -155,31 +159,33 @@ cleanup:
 void
 mu_test_client__agg_1(void)
 {
-  test_client_agg(1, 133, true);
+  test_client_agg(1, 133, 32, true);
 }
 
 void
 mu_test_client__agg_2(void)
 {
-  test_client_agg(2, 133, true);
+  test_client_agg(2, 133, 32, true);
 }
 
 void
 mu_test_client__agg_10(void)
 {
-  test_client_agg(10, 133, true);
+  test_client_agg(10, 133, 32, true);
 }
 
 void
 mu_test_client__agg_max(void)
 {
-  int max = MIN(PrioConfig_maxDataFields(), 4000);
-  test_client_agg(10, max, true);
+  int prec = 32;
+  int max = MIN(PrioConfig_maxDataFields(prec), 500);
+  test_client_agg(10, max, prec, true);
 }
 
 void
 mu_test_client__agg_max_bad(void)
 {
-  int max = PrioConfig_maxDataFields();
-  test_client_agg(10, max + 1, false);
+  int prec = 32;
+  int max = PrioConfig_maxDataFields(prec);
+  test_client_agg(10, max + 1, prec, false);
 }

--- a/ptest/encode_test.c
+++ b/ptest/encode_test.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2020, Daniel Reusche
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <mpi.h>
+#include <mprio.h>
+
+#include "mutest.h"
+#include "prio/config.h"
+#include "prio/encode.h"
+#include "prio/util.h"
+#include "test_util.h"
+
+void
+gen_client_data(int fields, int prec, long* data, int tweak)
+{
+  long max = (1l << (prec)) - 1;
+
+  // Produce valid values (fields < max)
+  if (tweak == 0) {
+    for (int i = 0; i < fields; i++) {
+      data[i] = max - i;
+    }
+  }
+
+  // Produce values which are too big
+  if (tweak == 1) {
+    for (int i = 0; i < fields; i++) {
+      data[i] = max + i;
+    }
+  }
+
+  // Produce negative values
+  if (tweak == 2) {
+    for (int i = 0; i < fields; i++) {
+      data[i] = 0 - i;
+    }
+  }
+
+  // Produce another ser of valid values (fields < max)
+  if (tweak == 3) {
+    for (int i = 0; i < fields; i++) {
+      data[i] = max - i - 1;
+    }
+  }
+}
+
+// Compute x from bits
+SECStatus
+check_bits(EInt in)
+{
+  SECStatus rv = SECSuccess;
+  mp_int tmp;
+  mp_int accum;
+  MP_DIGITS(&tmp) = NULL;
+  MPT_CHECKC(mp_init(&tmp));
+  MP_DIGITS(&accum) = NULL;
+  MPT_CHECKC(mp_init(&accum));
+
+  for (int b = 0; b < in->prec; b++) {
+    // count exponents down because of Big-endianness
+    MPT_CHECKC(mp_mul_d(&in->bits->data[b], (1l << (in->prec - b - 1)), &tmp));
+    MPT_CHECKC(mp_add(&tmp, &accum, &accum));
+  }
+  MPT_CHECKC(mp_cmp(&in->x, &accum)); // MP_EQ == MP_OKAY
+
+cleanup:
+  mp_clear(&tmp);
+  mp_clear(&accum);
+  return rv;
+}
+
+SECStatus
+check_encoding(EInt enc, long in)
+{
+  SECStatus rv = SECSuccess;
+  mp_int tmp;
+
+  MP_DIGITS(&tmp) = NULL;
+  MP_CHECKC(mp_init(&tmp));
+  mp_set_int(&tmp, in);
+
+  // Check wether x is the correct integer
+  MP_CHECKC(mp_cmp(&enc->x, &tmp));
+
+  // Check wether the bits represent x correctly
+  P_CHECKC(check_bits(enc));
+
+cleanup:
+  mp_clear(&tmp);
+  return rv;
+}
+
+void
+test_encoding(int tweak)
+{
+  SECStatus rv = SECSuccess;
+  int fields = 10;
+  int prec = 32;
+
+  long* data = NULL;
+  EInt enc = NULL;
+
+  P_CHECKA(data = calloc(fields, sizeof(long)));
+  gen_client_data(fields, prec, data, tweak);
+
+  for (int i = 0; i < fields; i++) {
+    PT_CHECKA(enc = EInt_new(prec));
+    MP_CHECKC(EInt_set(enc, data[i]));
+    P_CHECKC(check_encoding(enc, data[i]));
+    EInt_clear(enc);
+  }
+
+cleanup:
+  if (tweak == 0) {
+    mu_check(rv == SECSuccess);
+  } else if (tweak == 1) {
+    mu_check(rv == SECFailure);
+  } else if (tweak == 1) {
+    mu_check(rv == SECFailure);
+  }
+  if (data)
+    free(data);
+  if (rv != SECSuccess)
+    EInt_clear(enc);
+}
+
+void
+test_e_int_array(int tweak)
+{
+  SECStatus rv = SECSuccess;
+  int fields = 10;
+  unsigned int prec = 32;
+
+  long* data = NULL;
+  EIntArray arr = NULL;
+
+  P_CHECKA(data = calloc(fields, sizeof(long)));
+  gen_client_data(fields, prec, data, tweak);
+
+  P_CHECKA(arr = EIntArray_new_data(fields, prec, data));
+
+  for (int i = 0; i < fields; i++) {
+    P_CHECKC(check_encoding(arr->data[i], data[i]));
+  }
+
+cleanup:
+  if (tweak == 0) {
+    mu_check(rv == SECSuccess);
+  } else if (tweak == 1) {
+    mu_check(rv == SECFailure);
+  } else if (tweak == 1) {
+    mu_check(rv == SECFailure);
+  }
+  if (data)
+    free(data);
+  EIntArray_clear(arr);
+}
+
+void
+test_e_int_array_eq(int tweak)
+{
+  SECStatus rv = SECSuccess;
+  int fields = 10;
+  unsigned int prec = 32;
+
+  long* data1 = NULL;
+  EIntArray arr1 = NULL;
+
+  long* data2 = NULL;
+  EIntArray arr2 = NULL;
+
+  P_CHECKA(data1 = calloc(fields, sizeof(long)));
+  gen_client_data(fields, prec, data1, 0);
+  P_CHECKA(arr1 = EIntArray_new_data(fields, prec, data1));
+
+  if (tweak == 0) {
+    P_CHECKA(data2 = calloc(fields, sizeof(long)));
+    gen_client_data(fields, prec, data2, 0);
+    P_CHECKA(arr2 = EIntArray_new_data(fields, prec, data2));
+  }
+  if (tweak == 1) {
+    P_CHECKA(data2 = calloc(fields, sizeof(long)));
+    gen_client_data(fields, prec, data2, 3);
+    P_CHECKA(arr2 = EIntArray_new_data(fields, prec, data2));
+  }
+
+  P_CHECKCB(EIntArray_areEqual(arr1, arr2));
+
+cleanup:
+  if (tweak == 0) {
+    mu_check(rv == SECSuccess);
+  } else if (tweak == 1) {
+    mu_check(rv == SECFailure);
+  }
+  if (data1)
+    free(data1);
+  if (data2)
+    free(data2);
+
+  EIntArray_clear(arr1);
+  EIntArray_clear(arr2);
+}
+
+// Encode values of up to given precision
+void
+mu_test_encode__valid_0(void)
+{
+  test_encoding(0);
+}
+
+void
+mu_test_e_int_array__valid_0(void)
+{
+  test_e_int_array(0);
+}
+
+// Fail on positive values which require more precision
+void
+mu_test_encode__invalid_1(void)
+{
+  test_encoding(1);
+}
+
+void
+mu_test_e_int_array__invalid_1(void)
+{
+  test_e_int_array(1);
+}
+
+// Fail on negative values
+void
+mu_test_encode__invalid_2(void)
+{
+  test_encoding(2);
+}
+
+void
+mu_test_e_int_array__invalid_2(void)
+{
+  test_e_int_array(2);
+}
+
+// Test equal arrays
+void
+mu_test_e_int_array__eq(void)
+{
+  test_e_int_array_eq(0);
+}
+
+// Test inequal arrays
+void
+mu_test_e_int_array__neq(void)
+{
+  test_e_int_array_eq(1);
+}

--- a/ptest/encrypt_test.c
+++ b/ptest/encrypt_test.c
@@ -63,8 +63,8 @@ test_encrypt_once(int bad, unsigned int inlen)
   unsigned int encryptedBytes;
   PT_CHECKC(Keypair_new(&pvtkey, &pubkey));
   PT_CHECKC(Keypair_new(&pvtkey2, &pubkey2));
-  PT_CHECKC(PublicKey_encrypt(pubkey, bytes_enc, &encryptedBytes, enclen,
-                              bytes_in, inlen));
+  PT_CHECKC(PublicKey_encrypt(
+    pubkey, bytes_enc, &encryptedBytes, enclen, bytes_in, inlen));
   mu_check(encryptedBytes == enclen);
 
   if (bad == 1)
@@ -82,8 +82,8 @@ test_encrypt_once(int bad, unsigned int inlen)
 
   unsigned int decryptedBytes;
   PrivateKey key_to_use = (bad == 4) ? pvtkey2 : pvtkey;
-  P_CHECKC(PrivateKey_decrypt(key_to_use, bytes_dec, &decryptedBytes, declen,
-                              bytes_enc, enclen));
+  P_CHECKC(PrivateKey_decrypt(
+    key_to_use, bytes_dec, &decryptedBytes, declen, bytes_enc, enclen));
   mu_check(decryptedBytes == inlen);
   mu_check(!strncmp((char*)bytes_in, (char*)bytes_dec, inlen));
 
@@ -220,21 +220,21 @@ test_export_privkey(int zeros)
     memset(privData, 0, 5);
   }
 
-  PT_CHECKC(PrivateKey_import(&pvtkey_imp, privData, CURVE25519_KEY_LEN,
-                              pubData, CURVE25519_KEY_LEN));
+  PT_CHECKC(PrivateKey_import(
+    &pvtkey_imp, privData, CURVE25519_KEY_LEN, pubData, CURVE25519_KEY_LEN));
   PT_CHECKC(PrivateKey_export(pvtkey_imp, privData2, CURVE25519_KEY_LEN));
 
   mu_check(!memcmp(privData, privData2, CURVE25519_KEY_LEN));
 
   if (!zeros) {
     unsigned int outputLen;
-    PT_CHECKC(PublicKey_encrypt(pubkey, output, &outputLen, sizeof(output),
-                                input, sizeof(input)));
+    PT_CHECKC(PublicKey_encrypt(
+      pubkey, output, &outputLen, sizeof(output), input, sizeof(input)));
 
     // Check that can decrypt with imported private key.
     unsigned int plainLen;
-    PT_CHECKC(PrivateKey_decrypt(pvtkey_imp, decrypt, &plainLen,
-                                 sizeof(decrypt), output, outputLen));
+    PT_CHECKC(PrivateKey_decrypt(
+      pvtkey_imp, decrypt, &plainLen, sizeof(decrypt), output, outputLen));
 
     mu_check(plainLen == sizeof(input));
     mu_check(!memcmp(input, decrypt, sizeof(input)));
@@ -288,8 +288,11 @@ test_export_hex_privkey(int zeros)
     memset(privData, '0', 5);
   }
 
-  PT_CHECKC(PrivateKey_import_hex(&pvtkey_imp, privData, CURVE25519_KEY_LEN_HEX,
-                                  pubData, CURVE25519_KEY_LEN_HEX));
+  PT_CHECKC(PrivateKey_import_hex(&pvtkey_imp,
+                                  privData,
+                                  CURVE25519_KEY_LEN_HEX,
+                                  pubData,
+                                  CURVE25519_KEY_LEN_HEX));
   PT_CHECKC(
     PrivateKey_export_hex(pvtkey_imp, privData2, CURVE25519_KEY_LEN_HEX + 1));
 
@@ -297,13 +300,13 @@ test_export_hex_privkey(int zeros)
 
   if (!zeros) {
     unsigned int outputLen;
-    PT_CHECKC(PublicKey_encrypt(pubkey, output, &outputLen, sizeof(output),
-                                input, sizeof(input)));
+    PT_CHECKC(PublicKey_encrypt(
+      pubkey, output, &outputLen, sizeof(output), input, sizeof(input)));
 
     // Check that can decrypt with imported private key.
     unsigned int plainLen;
-    PT_CHECKC(PrivateKey_decrypt(pvtkey_imp, decrypt, &plainLen,
-                                 sizeof(decrypt), output, outputLen));
+    PT_CHECKC(PrivateKey_decrypt(
+      pvtkey_imp, decrypt, &plainLen, sizeof(decrypt), output, outputLen));
 
     mu_check(plainLen == sizeof(input));
     mu_check(!memcmp(input, decrypt, sizeof(input)));
@@ -368,10 +371,10 @@ mu_test_export_hex(void)
   unsigned char hex_bytes2[2 * CURVE25519_KEY_LEN + 1];
 
   // Make sure that invalid lengths are rejected.
-  mu_check(PublicKey_import_hex(&pubkey, hex_bytes,
-                                2 * CURVE25519_KEY_LEN - 1) == SECFailure);
-  mu_check(PublicKey_import_hex(&pubkey, hex_bytes,
-                                2 * CURVE25519_KEY_LEN + 1) == SECFailure);
+  mu_check(PublicKey_import_hex(
+             &pubkey, hex_bytes, 2 * CURVE25519_KEY_LEN - 1) == SECFailure);
+  mu_check(PublicKey_import_hex(
+             &pubkey, hex_bytes, 2 * CURVE25519_KEY_LEN + 1) == SECFailure);
 
   // Import a key in upper-case hex
   PT_CHECKC(PublicKey_import_hex(&pubkey, hex_bytes, 2 * CURVE25519_KEY_LEN));
@@ -393,10 +396,10 @@ mu_test_export_hex(void)
     mu_check(raw_bytes[i] == raw_bytes_should[i]);
   }
 
-  mu_check(PublicKey_import(&pubkey, raw_bytes_should,
-                            CURVE25519_KEY_LEN - 1) == SECFailure);
-  mu_check(PublicKey_import(&pubkey, raw_bytes_should,
-                            CURVE25519_KEY_LEN + 1) == SECFailure);
+  mu_check(PublicKey_import(
+             &pubkey, raw_bytes_should, CURVE25519_KEY_LEN - 1) == SECFailure);
+  mu_check(PublicKey_import(
+             &pubkey, raw_bytes_should, CURVE25519_KEY_LEN + 1) == SECFailure);
 
   // Import a raw key and export as hex
   PT_CHECKC(PublicKey_import(&pubkey, raw_bytes_should, CURVE25519_KEY_LEN));

--- a/ptest/fft_test.c
+++ b/ptest/fft_test.c
@@ -25,7 +25,7 @@ mu_test__fft_one(void)
   MPArray points_in = NULL;
   MPArray points_out = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(123));
+  PT_CHECKA(cfg = PrioConfig_newTest(123, 16));
   PT_CHECKA(points_in = MPArray_new(1));
   PT_CHECKA(points_out = MPArray_new(1));
 
@@ -52,7 +52,7 @@ mu_test__fft_roots(void)
   mp_int tmp;
   MP_DIGITS(&tmp) = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(90));
+  PT_CHECKA(cfg = PrioConfig_newTest(90, 16));
   PT_CHECKA(roots = MPArray_new(4));
   MPT_CHECKC(mp_init(&tmp));
 
@@ -85,7 +85,7 @@ mu_test__fft_simple(void)
   MP_DIGITS(&should_be) = NULL;
   MP_DIGITS(&tmp) = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(140));
+  PT_CHECKA(cfg = PrioConfig_newTest(140, 16));
   PT_CHECKA(points_in = MPArray_new(nPoints));
   PT_CHECKA(points_out = MPArray_new(nPoints));
   PT_CHECKA(roots = MPArray_new(nPoints));
@@ -144,7 +144,7 @@ mu_test__fft_invert(void)
   MPArray points_out2 = NULL;
   MPArray roots = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(91));
+  PT_CHECKA(cfg = PrioConfig_newTest(91, 16));
   PT_CHECKA(points_in = MPArray_new(nPoints));
   PT_CHECKA(points_out = MPArray_new(nPoints));
   PT_CHECKA(points_out2 = MPArray_new(nPoints));

--- a/ptest/mutest.c
+++ b/ptest/mutest.c
@@ -76,14 +76,19 @@ main(int argc, char* argv[])
 
   Prio_clear();
 
-  mu_print(MU_SUMMARY, "\n"
-                       "Tests done:\n"
-                       "\t%d test suite(s) passed, %d failed, %d skipped.\n"
-                       "\t%d test case(s) passed, %d failed.\n"
-                       "\t%d check(s) passed, %d failed.\n"
-                       "\n",
-           mutest_passed_suites, mutest_failed_suites, mutest_skipped_suites,
-           mutest_passed_cases, mutest_failed_cases, mutest_passed_checks,
+  mu_print(MU_SUMMARY,
+           "\n"
+           "Tests done:\n"
+           "\t%d test suite(s) passed, %d failed, %d skipped.\n"
+           "\t%d test case(s) passed, %d failed.\n"
+           "\t%d check(s) passed, %d failed.\n"
+           "\n",
+           mutest_passed_suites,
+           mutest_failed_suites,
+           mutest_skipped_suites,
+           mutest_passed_cases,
+           mutest_failed_cases,
+           mutest_passed_checks,
            mutest_failed_checks);
 
   return (mutest_failed_suites + mutest_skipped_suites) ? 1 : 0;

--- a/ptest/mutest.h
+++ b/ptest/mutest.h
@@ -17,37 +17,42 @@
 #include <stdio.h> /* fprintf() */
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* verbosity level (each level shows all the previous levels too) */
-enum {
-	MU_QUIET = 0, /* be completely quiet */
-	MU_ERROR,     /* shows errors only */
-	MU_SUMMARY,   /* shows a summary */
-	MU_SUITE,     /* shows test suites progress */
-	MU_CASE,      /* shows test cases progress */
-	MU_CHECK      /* shows the current running check */
-};
+  /* verbosity level (each level shows all the previous levels too) */
+  enum
+  {
+    MU_QUIET = 0, /* be completely quiet */
+    MU_ERROR,     /* shows errors only */
+    MU_SUMMARY,   /* shows a summary */
+    MU_SUITE,     /* shows test suites progress */
+    MU_CASE,      /* shows test cases progress */
+    MU_CHECK      /* shows the current running check */
+  };
 
 /* print a message according to the verbosity level */
-#define mu_print(level, ...) \
-	do { \
-		if (mutest_verbose_level >= level) { \
-			if (mutest_verbose_level == MU_ERROR) \
-				fprintf(stderr, __VA_ARGS__); \
-			else \
-				fprintf(stdout, __VA_ARGS__); \
-		} \
-	} while (0)
+#define mu_print(level, ...)                                                   \
+  do {                                                                         \
+    if (mutest_verbose_level >= level) {                                       \
+      if (mutest_verbose_level == MU_ERROR)                                    \
+        fprintf(stderr, __VA_ARGS__);                                          \
+      else                                                                     \
+        fprintf(stdout, __VA_ARGS__);                                          \
+    }                                                                          \
+  } while (0)
 
 /* print an error message */
-#define mu_printerr(name, action) \
-		mu_print(MU_ERROR, __FILE__ ":%d: " name " failed, "\
-				action " test case\n", __LINE__);
+#define mu_printerr(name, action)                                              \
+  mu_print(MU_ERROR,                                                           \
+           __FILE__ ":%d: " name " failed, " action " test case\n",            \
+           __LINE__);
 
 /* modify the internal state so a failure gets counted */
-#define mutest_count_err ++mutest_failed_checks; mutest_case_failed = 1;
+#define mutest_count_err                                                       \
+  ++mutest_failed_checks;                                                      \
+  mutest_case_failed = 1;
 
 /* modify the internal state so a success gets counted */
 #define mutest_count_suc ++mutest_passed_checks;
@@ -57,22 +62,26 @@ enum {
 #include <exception>
 
 /* print an error message triggered by a C++ exception */
-#define mu_printex(name, action, ex) \
-		mu_print(MU_ERROR, __FILE__ ":%d: " name " failed, " \
-				"exception thrown (%s), " action \
-				" test case\n", __LINE__, ex);
+#define mu_printex(name, action, ex)                                           \
+  mu_print(MU_ERROR,                                                           \
+           __FILE__ ":%d: " name " failed, "                                   \
+                    "exception thrown (%s), " action " test case\n",           \
+           __LINE__,                                                           \
+           ex);
 
 #define mutest_try try {
-#define mutest_catch(name, action, final) \
-		} catch (const std::exception& e) { \
-			mutest_count_err \
-			mu_printex(name, action, e.what()); \
-			final; \
-		} catch (...) { \
-			mutest_count_err \
-			mu_printex(name, action, "[unknown]"); \
-			final; \
-		}
+#define mutest_catch(name, action, final)                                      \
+  }                                                                            \
+  catch (const std::exception& e)                                              \
+  {                                                                            \
+    mutest_count_err mu_printex(name, action, e.what());                       \
+    final;                                                                     \
+  }                                                                            \
+  catch (...)                                                                  \
+  {                                                                            \
+    mutest_count_err mu_printex(name, action, "[unknown]");                    \
+    final;                                                                     \
+  }
 
 #else /* !__cplusplus */
 
@@ -82,18 +91,16 @@ enum {
 #endif /* __cplusplus */
 
 /* check that an expression evaluates to true, continue if the check fails */
-#define mu_check_base(exp, name, action, final) \
-	do { \
-		mu_print(MU_CHECK, "\t\t* Checking " name "(" #exp ")...\n"); \
-		mutest_try \
-			if (exp) mutest_count_suc \
-			else { \
-				mutest_count_err \
-				mu_printerr(name "(" #exp ")", action); \
-				final; \
-			} \
-		mutest_catch(name, action, final) \
-	} while (0)
+#define mu_check_base(exp, name, action, final)                                \
+  do {                                                                         \
+    mu_print(MU_CHECK, "\t\t* Checking " name "(" #exp ")...\n");              \
+    mutest_try if (exp) mutest_count_suc else                                  \
+    {                                                                          \
+      mutest_count_err mu_printerr(name "(" #exp ")", action);                 \
+      final;                                                                   \
+    }                                                                          \
+    mutest_catch(name, action, final)                                          \
+  } while (0)
 
 /* check that an expression evaluates to true, continue if the check fails */
 #define mu_check(exp) mu_check_base(exp, "mu_check", "resuming", continue)
@@ -102,124 +109,125 @@ enum {
  * ensure that an expression evaluates to true, abort the current test
  * case if the check fails
  */
-#define mu_ensure(exp) mu_check_base(exp, "mu_ensure", "aborting", return)
+#define mu_ensure(exp) mu_check_base(exp, "mu_ensure", "aborting", return )
 
 #ifdef __cplusplus
 
-#define mu_echeck_base(ex, exp, name, action, final) \
-	do { \
-		mu_print(MU_CHECK, "\t\t* Checking " name "(" #ex ", " #exp \
-				")...\n"); \
-		try { \
-			exp; \
-			mutest_count_err \
-			mu_printerr(name "(" #ex ", " #exp ")", \
-					"no exception thrown, "	action); \
-			final; \
-		} catch (const ex& e) { \
-			mutest_count_suc \
-		} catch (const std::exception& e) { \
-			mutest_count_err \
-			mu_printex(name "(" #ex ", " #exp ")", action, \
-					e.what()); \
-			final; \
-		} catch (...) { \
-			mutest_count_err \
-			mu_printex(name "(" #ex ", " #exp ")", action, \
-					"[unknown]"); \
-			final; \
-		} \
-	} while (0)
+#define mu_echeck_base(ex, exp, name, action, final)                           \
+  do {                                                                         \
+    mu_print(MU_CHECK, "\t\t* Checking " name "(" #ex ", " #exp ")...\n");     \
+    try {                                                                      \
+      exp;                                                                     \
+      mutest_count_err mu_printerr(name "(" #ex ", " #exp ")",                 \
+                                   "no exception thrown, " action);            \
+      final;                                                                   \
+    } catch (const ex& e) {                                                    \
+      mutest_count_suc                                                         \
+    } catch (const std::exception& e) {                                        \
+      mutest_count_err mu_printex(                                             \
+        name "(" #ex ", " #exp ")", action, e.what());                         \
+      final;                                                                   \
+    } catch (...) {                                                            \
+      mutest_count_err mu_printex(                                             \
+        name "(" #ex ", " #exp ")", action, "[unknown]");                      \
+      final;                                                                   \
+    }                                                                          \
+  } while (0)
 
 /*
  * check that an expression throws a particular exception, continue if the
  * check fails
  */
-#define mu_echeck(ex, exp) \
-	mu_echeck_base(ex, exp, "mu_echeck", "resuming", continue)
+#define mu_echeck(ex, exp)                                                     \
+  mu_echeck_base(ex, exp, "mu_echeck", "resuming", continue)
 
 /*
  * ensure that an expression throws a particular exception, abort the current
  * test case if the check fails
  */
-#define mu_eensure(ex, exp) \
-	mu_echeck_base(ex, exp, "mu_eensure", "aborting", return)
+#define mu_eensure(ex, exp)                                                    \
+  mu_echeck_base(ex, exp, "mu_eensure", "aborting", return )
 
 #endif /* __cplusplus */
 
 #ifndef MUTEST_PY /* we are using the C implementation */
 
-/*
- * this function implements the test suites execution, you should generate
- * a module with this function using mkmutest, or take a look to that script
- * if you want to implement your own customized version */
-void mu_run_suites();
+  /*
+   * this function implements the test suites execution, you should generate
+   * a module with this function using mkmutest, or take a look to that script
+   * if you want to implement your own customized version */
+  void mu_run_suites();
 
 /* macro for running a single initialization function */
 #ifndef mu_run_init
-#define mu_run_init(name) \
-	{ \
-		int name(); \
-		int r; \
-		mu_print(MU_CASE, "\t+ Executing initialization function " \
-				"'" #name "'...\n"); \
-		if ((r = name())) { \
-			mu_print(MU_ERROR, "%s:" #name ": initialization " \
-					"function failed (returned %d), " \
-					"skipping test suite...\n", \
-					mutest_suite_name, r); \
-			++mutest_skipped_suites; \
-			break; \
-		} \
-	} do { } while (0)
+#define mu_run_init(name)                                                      \
+  {                                                                            \
+    int name();                                                                \
+    int r;                                                                     \
+    mu_print(MU_CASE,                                                          \
+             "\t+ Executing initialization function "                          \
+             "'" #name "'...\n");                                              \
+    if ((r = name())) {                                                        \
+      mu_print(MU_ERROR,                                                       \
+               "%s:" #name ": initialization "                                 \
+               "function failed (returned %d), "                               \
+               "skipping test suite...\n",                                     \
+               mutest_suite_name,                                              \
+               r);                                                             \
+      ++mutest_skipped_suites;                                                 \
+      break;                                                                   \
+    }                                                                          \
+  }                                                                            \
+  do {                                                                         \
+  } while (0)
 #endif /* mu_run_init */
 
 /* macro for running a single test case */
 #ifndef mu_run_case
-#define mu_run_case(name) \
-	do { \
-		mu_print(MU_CASE, "\t* Executing test case '" #name "'...\n");\
-		mutest_case_name = #name; \
-		void name(); \
-		name(); \
-		if (mutest_case_failed) { \
-			++mutest_failed_cases; \
-			mutest_suite_failed = 1; \
-		} else ++mutest_passed_cases; \
-		mutest_case_failed = 0; \
-	} while (0)
+#define mu_run_case(name)                                                      \
+  do {                                                                         \
+    mu_print(MU_CASE, "\t* Executing test case '" #name "'...\n");             \
+    mutest_case_name = #name;                                                  \
+    void name();                                                               \
+    name();                                                                    \
+    if (mutest_case_failed) {                                                  \
+      ++mutest_failed_cases;                                                   \
+      mutest_suite_failed = 1;                                                 \
+    } else                                                                     \
+      ++mutest_passed_cases;                                                   \
+    mutest_case_failed = 0;                                                    \
+  } while (0)
 #endif /* mu_run_case */
 
 /* macro for running a single termination function */
 #ifndef mu_run_term
-#define mu_run_term(name) \
-	do { \
-		mu_print(MU_CASE, "\t- Executing termination function '" \
-				#name "'...\n"); \
-		void name(); \
-		name(); \
-	} while (0)
+#define mu_run_term(name)                                                      \
+  do {                                                                         \
+    mu_print(MU_CASE, "\t- Executing termination function '" #name "'...\n");  \
+    void name();                                                               \
+    name();                                                                    \
+  } while (0)
 #endif /* mu_run_term */
 
-/*
- * mutest exported variables for internal use, do not use directly unless you
- *  know what you're doing.
- */
-extern const char* mutest_suite_name;
-extern int mutest_failed_suites;
-extern int mutest_passed_suites;
-extern int mutest_skipped_suites;
-extern int mutest_suite_failed;
-/* test cases */
-extern const char* mutest_case_name;
-extern int mutest_failed_cases;
-extern int mutest_passed_cases;
-extern int mutest_case_failed;
-/* checks */
-extern int mutest_failed_checks;
-extern int mutest_passed_checks;
-/* verbosity */
-extern int mutest_verbose_level;
+  /*
+   * mutest exported variables for internal use, do not use directly unless you
+   *  know what you're doing.
+   */
+  extern const char* mutest_suite_name;
+  extern int mutest_failed_suites;
+  extern int mutest_passed_suites;
+  extern int mutest_skipped_suites;
+  extern int mutest_suite_failed;
+  /* test cases */
+  extern const char* mutest_case_name;
+  extern int mutest_failed_cases;
+  extern int mutest_passed_cases;
+  extern int mutest_case_failed;
+  /* checks */
+  extern int mutest_failed_checks;
+  extern int mutest_passed_checks;
+  /* verbosity */
+  extern int mutest_verbose_level;
 
 #else /* MUTEST_PY is defined, using the Python implementation */
 
@@ -230,14 +238,18 @@ int mutest_case_failed; /* unused, for C implementation compatibility */
 
 int mutest_passed_checks;
 int mutest_failed_checks;
-void mutest_reset_counters() {
-	mutest_passed_checks = 0;
-	mutest_failed_checks = 0;
+void
+mutest_reset_counters()
+{
+  mutest_passed_checks = 0;
+  mutest_failed_checks = 0;
 }
 
 int mutest_verbose_level = MU_ERROR;
-void mutest_set_verbose_level(int val) {
-	mutest_verbose_level = val;
+void
+mutest_set_verbose_level(int val)
+{
+  mutest_verbose_level = val;
 }
 
 #endif /* MUTEST_PY */
@@ -245,4 +257,3 @@ void mutest_set_verbose_level(int val) {
 #ifdef __cplusplus
 }
 #endif
-

--- a/ptest/prg_test.c
+++ b/ptest/prg_test.c
@@ -339,8 +339,8 @@ mu_test__prg_share_arr(void)
   PT_CHECKC(PRG_get_array(prg, arr, &cfg->modulus));
 
   for (int i = 0; i < 10; i++) {
-    MPT_CHECKC(mp_addmod(&arr->data[i], &arr_share->data[i], &cfg->modulus,
-                         &arr->data[i]));
+    MPT_CHECKC(mp_addmod(
+      &arr->data[i], &arr_share->data[i], &cfg->modulus, &arr->data[i]));
     mu_check(mp_cmp_d(&arr->data[i], i) == 0);
   }
 

--- a/ptest/rand_test.c
+++ b/ptest/rand_test.c
@@ -12,7 +12,6 @@
 #include "prio/rand.h"
 #include "prio/util.h"
 #include "test_util.h"
-#include "test_util.h"
 
 void
 mu_test__util_msb_mast(void)

--- a/ptest/serial_test.c
+++ b/ptest/serial_test.c
@@ -19,7 +19,8 @@
 #include "test_util.h"
 
 SECStatus
-gen_client_packets(const_PrioConfig cfg, PrioPacketClient pA,
+gen_client_packets(const_PrioConfig cfg,
+                   PrioPacketClient pA,
                    PrioPacketClient pB)
 {
   SECStatus rv = SECSuccess;

--- a/ptest/serial_test.c
+++ b/ptest/serial_test.c
@@ -26,11 +26,14 @@ gen_client_packets(const_PrioConfig cfg,
   SECStatus rv = SECSuccess;
 
   const int ndata = cfg->num_data_fields;
-  bool* data_items = NULL;
-  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  const int prec = cfg->precision;
+  long max = (1l << (prec)) - 1;
+
+  long* data_items = NULL;
+  PT_CHECKA(data_items = calloc(ndata, sizeof(long)));
 
   for (int i = 0; i < ndata; i++) {
-    data_items[i] = (i % 3 == 1) || (i % 5 == 3);
+    data_items[i] = max - i;
   }
 
   PT_CHECKC(PrioPacketClient_set_data(cfg, data_items, pA, pB));
@@ -67,8 +70,9 @@ serial_client(int bad)
   msgpack_sbuffer_init(&sbufB);
   msgpack_packer_init(&pkB, &sbufB, msgpack_sbuffer_write);
 
-  PT_CHECKA(cfg = PrioConfig_new(100, NULL, NULL, batch_id1, batch_id_len));
-  PT_CHECKA(cfg2 = PrioConfig_new(100, NULL, NULL, batch_id2, batch_id_len));
+  PT_CHECKA(cfg = PrioConfig_new(100, 16, NULL, NULL, batch_id1, batch_id_len));
+  PT_CHECKA(cfg2 =
+              PrioConfig_new(100, 16, NULL, NULL, batch_id2, batch_id_len));
   PT_CHECKA(pA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
   PT_CHECKA(pB = PrioPacketClient_new(cfg, PRIO_SERVER_B));
   PT_CHECKA(qA = PrioPacketClient_new(cfg, PRIO_SERVER_A));
@@ -172,7 +176,7 @@ test_verify1(int bad)
   PrioPacketVerify1 v2 = NULL;
   PrioConfig cfg = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(1));
+  PT_CHECKA(cfg = PrioConfig_newTest(1, 16));
   PT_CHECKA(v1 = PrioPacketVerify1_new());
   PT_CHECKA(v2 = PrioPacketVerify1_new());
   mp_set(&v1->share_d, 4);
@@ -232,7 +236,7 @@ test_verify2(int bad)
   PrioPacketVerify2 v2 = NULL;
   PrioConfig cfg = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(1));
+  PT_CHECKA(cfg = PrioConfig_newTest(1, 16));
   PT_CHECKA(v1 = PrioPacketVerify2_new());
   PT_CHECKA(v2 = PrioPacketVerify2_new());
   mp_set(&v1->share_out, 4);
@@ -289,7 +293,7 @@ test_total_share(int bad)
   PrioTotalShare t2 = NULL;
   PrioConfig cfg = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest((bad == 2 ? 4 : 3)));
+  PT_CHECKA(cfg = PrioConfig_newTest((bad == 2 ? 4 : 3), 16));
   PT_CHECKA(t1 = PrioTotalShare_new());
   PT_CHECKA(t2 = PrioTotalShare_new());
 

--- a/ptest/server_test.c
+++ b/ptest/server_test.c
@@ -26,7 +26,7 @@ mu_test__eval_poly(void)
   MP_DIGITS(&eval_at) = NULL;
   MP_DIGITS(&out) = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(54));
+  PT_CHECKA(cfg = PrioConfig_newTest(54, 1));
   PT_CHECKA(coeffs = MPArray_new(3));
 
   mp_set(&coeffs->data[0], 2);
@@ -64,7 +64,7 @@ mu_test__verify_new(void)
   PrioVerifier vB = NULL;
   unsigned char* for_a = NULL;
   unsigned char* for_b = NULL;
-  bool* data_items = NULL;
+  long* data_items = NULL;
 
   mp_int fR, gR, hR;
   MP_DIGITS(&fR) = NULL;
@@ -77,13 +77,16 @@ mu_test__verify_new(void)
   PT_CHECKC(Keypair_new(&skA, &pkA));
   PT_CHECKC(Keypair_new(&skB, &pkB));
   PT_CHECKA(cfg =
-              PrioConfig_new(214, pkA, pkB, (unsigned char*)"testbatch", 9));
+              PrioConfig_new(214, 1, pkA, pkB, (unsigned char*)"testbatch", 9));
 
   const int ndata = PrioConfig_numDataFields(cfg);
-  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  const int prec = PrioConfig_precDataFields(cfg);
+
+  PT_CHECKA(data_items = calloc(ndata, sizeof(long)));
+  long max = (1l << (prec)) - 1;
   for (int i = 0; i < ndata; i++) {
     // Arbitrary data
-    data_items[i] = (i % 3 == 1) || (i % 5 == 3);
+    data_items[i] = max - i;
   }
 
   PT_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
@@ -163,7 +166,7 @@ verify_full(int tweak)
   PrioPacketVerify2 p2B = NULL;
   unsigned char* for_a = NULL;
   unsigned char* for_b = NULL;
-  bool* data_items = NULL;
+  long* data_items = NULL;
 
   mp_int fR, gR, hR;
   MP_DIGITS(&fR) = NULL;
@@ -175,13 +178,16 @@ verify_full(int tweak)
 
   PT_CHECKC(Keypair_new(&skA, &pkA));
   PT_CHECKC(Keypair_new(&skB, &pkB));
-  PT_CHECKA(cfg = PrioConfig_new(47, pkA, pkB, (unsigned char*)"test4", 5));
+  PT_CHECKA(cfg = PrioConfig_new(47, 1, pkA, pkB, (unsigned char*)"test4", 5));
 
   const int ndata = PrioConfig_numDataFields(cfg);
-  PT_CHECKA(data_items = calloc(ndata, sizeof(bool)));
+  const int prec = PrioConfig_precDataFields(cfg);
+
+  PT_CHECKA(data_items = calloc(ndata, sizeof(long)));
+  long max = (1l << (prec)) - 1;
   for (int i = 0; i < ndata; i++) {
     // Arbitrary data
-    data_items[i] = (i % 3 == 1) || (i % 5 == 3);
+    data_items[i] = max - i;
   }
 
   PT_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));

--- a/ptest/share_test.c
+++ b/ptest/share_test.c
@@ -29,7 +29,7 @@ mu_test_share(void)
   MP_DIGITS(&b) = NULL;
   MP_DIGITS(&c) = NULL;
 
-  PT_CHECKA(cfg = PrioConfig_newTest(93));
+  PT_CHECKA(cfg = PrioConfig_newTest(93, 16));
   PT_CHECKA(t1 = BeaverTriple_new());
   PT_CHECKA(t2 = BeaverTriple_new());
 

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -8,16 +8,16 @@ die() {
     exit 1
 }
 
-CLANG_FORMAT_VERSION="clang-format version 3.9"
+CLANG_FORMAT_VERSION="clang-format version 9.0"
 
-if which clang-format-3.9 > /dev/null; then
-    alias clang-format=clang-format-3.9
+if which clang-format-9 > /dev/null; then
+    alias clang-format=clang-format-9
 elif which clang-format > /dev/null; then
     case "$(clang-format --version)" in
         "$CLANG_FORMAT_VERSION"*)
             ;;
         *)
-            die "clang-format 3.9 required"
+            die "clang-format 9.0 required"
             ;;
     esac
 else


### PR DESCRIPTION
This is an implementation of the b-bit integer circuit as described in the prio paper.

It is explained in encode.h, circuit.h and prg.h.

If you notice any missing tests or my explanations in the comments prove to be insufficient, please let me know so I can fix that.

EIntArray interface handlers felt more natural to do this way but I could remodel them after mparray.h:
https://github.com/degregat/libprio/blob/c1295db54c6c45a9cb7da2688041391467c17ae2/prio/encode.c#L88

Some questions from my side so far: 
- Up to which b do we want to support. The maximum depends on how many submissions we want to fit into an usigned long long which also depends on the platform:
https://github.com/degregat/libprio/blob/a71fe8c26906aaa0f072086bdef8cb7b5ce7e96e/prio/config.c#L56

- Two regarding the use of msgpack, which was unclear to me from the msgpack-c documentation: Do we gain anything from using the msgpack arrays in the two places below:
https://github.com/degregat/libprio/blob/a71fe8c26906aaa0f072086bdef8cb7b5ce7e96e/prio/serial.c#L193
https://github.com/degregat/libprio/blob/a71fe8c26906aaa0f072086bdef8cb7b5ce7e96e/prio/serial.c#L210

- I am unsure about the parameters for the new EInt tests in prg_test:
https://github.com/degregat/libprio/blob/a71fe8c26906aaa0f072086bdef8cb7b5ce7e96e/ptest/prg_test.c#L419

- Should the maximum value be computed in PrioConfig? Apart from the following it only gets used in tests: https://github.com/degregat/libprio/blob/a71fe8c26906aaa0f072086bdef8cb7b5ce7e96e/prio/encode.c#L51

- Should tmp be allocated inside the accumulator or not:
https://github.com/degregat/libprio/blob/c1295db54c6c45a9cb7da2688041391467c17ae2/prio/prg.c#L123

I know this PR contains sizeable changes, so I am open to all feedback, discussion and reworking parts of this.