### PR TITLE
Expose NSS indirectly (for sandboxing)

### DIFF
--- a/include/mprio.h
+++ b/include/mprio.h
@@ -396,8 +396,8 @@ extern "C"
                                       const_PrioTotalShare tA,
                                       const_PrioTotalShare tB);
 
-#endif /* __PRIO_H__ */
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* __PRIO_H__ */

--- a/pclient/main.c
+++ b/pclient/main.c
@@ -44,7 +44,36 @@ verify_full(void)
   bool* data_items = NULL;
 
   // Initialize NSS random number generator.
-  P_CHECKC(Prio_init());
+  PrioNSSCtx globalNSS = { .NSS_IsInitialized = NSS_IsInitialized,
+                           .NSS_InitContext = NSS_InitContext,
+                           .NSS_ShutdownContext = NSS_ShutdownContext,
+                           .PK11_FreeSlot = PK11_FreeSlot,
+                           .PK11_GetInternalSlot = PK11_GetInternalSlot,
+                           .PK11_GenerateRandom = PK11_GenerateRandom,
+                           .PK11_FreeSymKey = PK11_FreeSymKey,
+                           .PK11_ImportSymKey = PK11_ImportSymKey,
+                           .PK11_PubDeriveWithKDF = PK11_PubDeriveWithKDF,
+                           .PK11_GenerateKeyPair = PK11_GenerateKeyPair,
+                           .PK11_Decrypt = PK11_Decrypt,
+                           .PK11_Encrypt = PK11_Encrypt,
+                           .PK11_ImportDERPrivateKeyInfoAndReturnKey =
+                             PK11_ImportDERPrivateKeyInfoAndReturnKey,
+                           .PK11_DestroyContext = PK11_DestroyContext,
+                           .PK11_CreateContextBySymKey =
+                             PK11_CreateContextBySymKey,
+                           .PK11_CipherOp = PK11_CipherOp,
+                           .PK11_ReadRawAttribute = PK11_ReadRawAttribute,
+                           .SECKEY_DestroyPrivateKey = SECKEY_DestroyPrivateKey,
+                           .SECKEY_DestroyPublicKey = SECKEY_DestroyPublicKey,
+                           .SECKEY_ExtractPublicKey = SECKEY_ExtractPublicKey,
+                           .SECKEY_DestroySubjectPublicKeyInfo =
+                             SECKEY_DestroySubjectPublicKeyInfo,
+                           .SECKEY_DecodeDERSubjectPublicKeyInfo =
+                             SECKEY_DecodeDERSubjectPublicKeyInfo,
+                           .SECITEM_ZfreeItem = SECITEM_ZfreeItem,
+                           .SECOID_FindOIDByTag = SECOID_FindOIDByTag };
+
+  P_CHECKC(Prio_init(&globalNSS));
 
   // Number of different boolean data fields we collect.
   const int ndata = 100;

--- a/pclient_uint/main.c
+++ b/pclient_uint/main.c
@@ -44,7 +44,34 @@ verify_full(void)
   long* data_items = NULL;
 
   // Initialize NSS random number generator.
-  P_CHECKC(Prio_init());
+  PrioNSSCtx globalNSS = {
+    .NSS_IsInitialized = NSS_IsInitialized,
+    .NSS_InitContext = NSS_InitContext,
+    .NSS_ShutdownContext = NSS_ShutdownContext,
+    .PK11_FreeSlot = PK11_FreeSlot,
+    .PK11_GetInternalSlot = PK11_GetInternalSlot,
+    .PK11_GenerateRandom = PK11_GenerateRandom,
+    .PK11_FreeSymKey = PK11_FreeSymKey,
+    .PK11_ImportSymKey = PK11_ImportSymKey,
+    .PK11_PubDeriveWithKDF = PK11_PubDeriveWithKDF,
+    .PK11_GenerateKeyPair = PK11_GenerateKeyPair,
+    .PK11_Decrypt = PK11_Decrypt,
+    .PK11_Encrypt = PK11_Encrypt,
+    .PK11_ImportDERPrivateKeyInfoAndReturnKey = PK11_ImportDERPrivateKeyInfoAndReturnKey,
+    .PK11_DestroyContext = PK11_DestroyContext,
+    .PK11_CreateContextBySymKey = PK11_CreateContextBySymKey,
+    .PK11_CipherOp = PK11_CipherOp,
+    .PK11_ReadRawAttribute = PK11_ReadRawAttribute,
+    .SECKEY_DestroyPrivateKey = SECKEY_DestroyPrivateKey,
+    .SECKEY_DestroyPublicKey = SECKEY_DestroyPublicKey,
+    .SECKEY_ExtractPublicKey = SECKEY_ExtractPublicKey,
+    .SECKEY_DestroySubjectPublicKeyInfo = SECKEY_DestroySubjectPublicKeyInfo,
+    .SECKEY_DecodeDERSubjectPublicKeyInfo = SECKEY_DecodeDERSubjectPublicKeyInfo,
+    .SECITEM_ZfreeItem = SECITEM_ZfreeItem,
+    .SECOID_FindOIDByTag = SECOID_FindOIDByTag
+  };
+
+  P_CHECKC(Prio_init(&globalNSS));
 
   // Number of different b-bit integer data fields we collect.
   const int ndata = 100;

--- a/prio/config.c
+++ b/prio/config.c
@@ -133,9 +133,12 @@ PrioConfig_numUIntEntries(const_PrioConfig cfg, int prec)
   return cfg->num_data_fields / prec;
 }
 
+PrioNSSCtx* prioGlobalNSS = NULL;
+
 SECStatus
-Prio_init(void)
+Prio_init(PrioNSSCtx* pNSS)
 {
+  prioGlobalNSS = pNSS;
   return rand_init();
 }
 

--- a/ptest/mutest.c
+++ b/ptest/mutest.c
@@ -68,8 +68,36 @@ parse_args(__attribute__((unused)) int argc, char* argv[])
 int
 main(int argc, char* argv[])
 {
+  PrioNSSCtx globalNSS = { .NSS_IsInitialized = NSS_IsInitialized,
+                           .NSS_InitContext = NSS_InitContext,
+                           .NSS_ShutdownContext = NSS_ShutdownContext,
+                           .PK11_FreeSlot = PK11_FreeSlot,
+                           .PK11_GetInternalSlot = PK11_GetInternalSlot,
+                           .PK11_GenerateRandom = PK11_GenerateRandom,
+                           .PK11_FreeSymKey = PK11_FreeSymKey,
+                           .PK11_ImportSymKey = PK11_ImportSymKey,
+                           .PK11_PubDeriveWithKDF = PK11_PubDeriveWithKDF,
+                           .PK11_GenerateKeyPair = PK11_GenerateKeyPair,
+                           .PK11_Decrypt = PK11_Decrypt,
+                           .PK11_Encrypt = PK11_Encrypt,
+                           .PK11_ImportDERPrivateKeyInfoAndReturnKey =
+                             PK11_ImportDERPrivateKeyInfoAndReturnKey,
+                           .PK11_DestroyContext = PK11_DestroyContext,
+                           .PK11_CreateContextBySymKey =
+                             PK11_CreateContextBySymKey,
+                           .PK11_CipherOp = PK11_CipherOp,
+                           .PK11_ReadRawAttribute = PK11_ReadRawAttribute,
+                           .SECKEY_DestroyPrivateKey = SECKEY_DestroyPrivateKey,
+                           .SECKEY_DestroyPublicKey = SECKEY_DestroyPublicKey,
+                           .SECKEY_ExtractPublicKey = SECKEY_ExtractPublicKey,
+                           .SECKEY_DestroySubjectPublicKeyInfo =
+                             SECKEY_DestroySubjectPublicKeyInfo,
+                           .SECKEY_DecodeDERSubjectPublicKeyInfo =
+                             SECKEY_DecodeDERSubjectPublicKeyInfo,
+                           .SECITEM_ZfreeItem = SECITEM_ZfreeItem,
+                           .SECOID_FindOIDByTag = SECOID_FindOIDByTag };
 
-  Prio_init();
+  Prio_init(&globalNSS);
   parse_args(argc, argv);
 
   mu_run_suites();


### PR DESCRIPTION
This supersedes #84. I've left mpi as is. We can do that in a separate patch, but I'm also okay with just sandboxing the mpi bits to start.

These are the MPI functions that I think we'd have to expose if we/when we want to extract out those bits.

```
mp_add
mp_addmod
mp_clear
mp_cmp
mp_cmp_d
mp_cmp_z
mp_copy
mp_exptmod_d
mp_init
mp_invmod
mp_mod
mp_mul_d
mp_mulmod
mp_read_radix
mp_read_unsigned_octets
mp_set
mp_sub
mp_sub_d
mp_submod
mp_to_fixlen_octets
mp_unsigned_octet_size
```