### PR TITLE
Add interface to serialize and merge server state

### DIFF
--- a/include/mprio.h
+++ b/include/mprio.h
@@ -274,6 +274,11 @@ extern "C"
                             const PrioPRGSeed serverSharedSecret);
   void PrioServer_clear(PrioServer s);
 
+  SECStatus PrioServer_write(const_PrioServer s, msgpack_packer *pk);
+  SECStatus PrioServer_read(PrioServer s,
+                            msgpack_unpacker *upk,
+                            const_PrioConfig cfg);
+
   /*
    * After receiving a client packet, each of the servers generate
    * a PrioVerifier object that they use to check whether the client's
@@ -345,6 +350,13 @@ extern "C"
    * above before aggregating any client data.
    */
   SECStatus PrioServer_aggregate(PrioServer s, PrioVerifier v);
+
+  /*
+   * Server state can be aggregated across multiple servers. This may be useful
+   * when aggregation for a batch is fanned out across multiple servers with the
+   * same configuration.
+   */
+  SECStatus PrioServer_merge(PrioServer s, const_PrioServer s_i);
 
   /*
    * After the servers have aggregated data packets from "enough" clients

--- a/include/mprio.h
+++ b/include/mprio.h
@@ -274,9 +274,9 @@ extern "C"
                             const PrioPRGSeed serverSharedSecret);
   void PrioServer_clear(PrioServer s);
 
-  SECStatus PrioServer_write(const_PrioServer s, msgpack_packer *pk);
+  SECStatus PrioServer_write(const_PrioServer s, msgpack_packer* pk);
   SECStatus PrioServer_read(PrioServer s,
-                            msgpack_unpacker *upk,
+                            msgpack_unpacker* upk,
                             const_PrioConfig cfg);
 
   /*

--- a/prio/serial.c
+++ b/prio/serial.c
@@ -410,6 +410,35 @@ cleanup:
 }
 
 SECStatus
+PrioServer_write(const_PrioServer s, msgpack_packer* pk)
+{
+  SECStatus rv = SECSuccess;
+  P_CHECKCB(pk != NULL);
+  P_CHECKCB(s != NULL);
+
+  P_CHECKC(serial_write_mp_array(pk, s->data_shares));
+
+cleanup:
+  return rv;
+}
+
+SECStatus
+PrioServer_read(PrioServer s,
+                msgpack_unpacker* upk,
+                const_PrioConfig cfg)
+{
+  SECStatus rv = SECSuccess;
+  P_CHECKCB(upk != NULL);
+  P_CHECKCB(s != NULL);
+
+  P_CHECKC(serial_read_mp_array(
+    upk, s->data_shares, cfg->num_data_fields, &cfg->modulus));
+
+cleanup:
+  return rv;
+}
+
+SECStatus
 PrioPacketVerify2_write(const_PrioPacketVerify2 p, msgpack_packer* pk)
 {
   SECStatus rv = SECSuccess;

--- a/prio/serial.c
+++ b/prio/serial.c
@@ -380,6 +380,36 @@ cleanup:
 }
 
 SECStatus
+PrioServer_write(const_PrioServer s, msgpack_packer* pk)
+{
+  SECStatus rv = SECSuccess;
+  P_CHECKCB(pk != NULL);
+  P_CHECKCB(s != NULL);
+
+  P_CHECKC(serial_write_mp_array(pk, s->data_shares));
+
+cleanup:
+  return rv;
+}
+
+SECStatus
+PrioServer_read(PrioServer s,
+                msgpack_unpacker* upk,
+                const_PrioConfig cfg)
+{
+  SECStatus rv = SECSuccess;
+  P_CHECKCB(upk != NULL);
+  P_CHECKCB(s != NULL);
+
+  P_CHECKC(serial_read_mp_array(
+    upk, s->data_shares, cfg->num_data_fields, &cfg->modulus));
+
+cleanup:
+  return rv;
+}
+
+
+SECStatus
 PrioPacketVerify1_write(const_PrioPacketVerify1 p, msgpack_packer* pk)
 {
   SECStatus rv = SECSuccess;
@@ -404,35 +434,6 @@ PrioPacketVerify1_read(PrioPacketVerify1 p,
 
   P_CHECKC(serial_read_mp_int(upk, &p->share_d, &cfg->modulus));
   P_CHECKC(serial_read_mp_int(upk, &p->share_e, &cfg->modulus));
-
-cleanup:
-  return rv;
-}
-
-SECStatus
-PrioServer_write(const_PrioServer s, msgpack_packer* pk)
-{
-  SECStatus rv = SECSuccess;
-  P_CHECKCB(pk != NULL);
-  P_CHECKCB(s != NULL);
-
-  P_CHECKC(serial_write_mp_array(pk, s->data_shares));
-
-cleanup:
-  return rv;
-}
-
-SECStatus
-PrioServer_read(PrioServer s,
-                msgpack_unpacker* upk,
-                const_PrioConfig cfg)
-{
-  SECStatus rv = SECSuccess;
-  P_CHECKCB(upk != NULL);
-  P_CHECKCB(s != NULL);
-
-  P_CHECKC(serial_read_mp_array(
-    upk, s->data_shares, cfg->num_data_fields, &cfg->modulus));
 
 cleanup:
   return rv;

--- a/prio/serial.c
+++ b/prio/serial.c
@@ -393,9 +393,7 @@ cleanup:
 }
 
 SECStatus
-PrioServer_read(PrioServer s,
-                msgpack_unpacker* upk,
-                const_PrioConfig cfg)
+PrioServer_read(PrioServer s, msgpack_unpacker* upk, const_PrioConfig cfg)
 {
   SECStatus rv = SECSuccess;
   P_CHECKCB(upk != NULL);
@@ -407,7 +405,6 @@ PrioServer_read(PrioServer s,
 cleanup:
   return rv;
 }
-
 
 SECStatus
 PrioPacketVerify1_write(const_PrioPacketVerify1 p, msgpack_packer* pk)

--- a/prio/server.c
+++ b/prio/server.c
@@ -83,6 +83,14 @@ PrioServer_aggregate(PrioServer s, PrioVerifier v)
   return MPArray_addmod(s->data_shares, arr, &s->cfg->modulus);
 }
 
+SECStatus
+PrioServer_merge(PrioServer s, const_PrioServer s_i)
+{
+  // TODO: check that the configuration files are exactly the same
+  return MPArray_addmod(s->data_shares, s_i->data_shares, &s->cfg->modulus);
+}
+
+
 PrioTotalShare
 PrioTotalShare_new(void)
 {

--- a/prio/server.c
+++ b/prio/server.c
@@ -86,10 +86,15 @@ PrioServer_aggregate(PrioServer s, PrioVerifier v)
 SECStatus
 PrioServer_merge(PrioServer s, const_PrioServer s_i)
 {
-  // TODO: check that the configuration files are exactly the same
+  if (s->cfg->num_data_fields != s_i->cfg->num_data_fields ||
+      mp_cmp(&s->cfg->modulus, &s_i->cfg->modulus) ||
+      strncmp((const char*)s->cfg->batch_id,
+              (const char*)s_i->cfg->batch_id,
+              s->cfg->batch_id_len)) {
+    return SECFailure;
+  }
   return MPArray_addmod(s->data_shares, s_i->data_shares, &s->cfg->modulus);
 }
-
 
 PrioTotalShare
 PrioTotalShare_new(void)

--- a/prio/server.c
+++ b/prio/server.c
@@ -83,7 +83,7 @@ PrioServer_aggregate(PrioServer s, PrioVerifier v)
   return MPArray_addmod(s->data_shares, arr, &s->cfg->modulus);
 }
 
-int
+static int
 public_key_cmp(const_PublicKey pub, const_PublicKey pub_other)
 {
   unsigned char data[CURVE25519_KEY_LEN];
@@ -100,7 +100,7 @@ public_key_cmp(const_PublicKey pub, const_PublicKey pub_other)
     (const char*)data, (const char*)data_other, CURVE25519_KEY_LEN);
 }
 
-int
+static int
 server_cmp(PrioServer s, const_PrioServer s_i)
 {
   return public_key_cmp(s->cfg->server_a_pub, s_i->cfg->server_a_pub) ||

--- a/ptest/serial_test.c
+++ b/ptest/serial_test.c
@@ -212,6 +212,8 @@ test_server(int bad)
 
 cleanup:
   mu_check(bad ? rv == SECFailure : rv == SECSuccess);
+  PublicKey_clear(pkA);
+  PrivateKey_clear(skA);
   PrioConfig_clear(cfg);
   PrioServer_clear(s1);
   PrioServer_clear(s2);

--- a/ptest/serial_test.c
+++ b/ptest/serial_test.c
@@ -205,11 +205,10 @@ test_server(int bad)
 
   P_CHECKC(PrioServer_read(s2, &upk, cfg));
 
-  mu_check(!mp_cmp(&s1->data_shares->data[0], &s2->data_shares->data[0]));
-  mu_check(!mp_cmp(&s1->data_shares->data[1], &s2->data_shares->data[1]));
+  mu_check(!mp_cmp(&s2->data_shares->data[0], &s1->data_shares->data[0]));
+  mu_check(!mp_cmp(&s2->data_shares->data[1], &s1->data_shares->data[1]));
   mu_check(!mp_cmp_d(&s2->data_shares->data[0], 4));
-  // the rest of the array is set with 0s
-  mu_check(!mp_cmp_d(&s2->data_shares->data[1], 0));
+  mu_check(!mp_cmp_d(&s2->data_shares->data[1], 10));
 
 cleanup:
   mu_check(bad ? rv == SECFailure : rv == SECSuccess);

--- a/ptest/server_test.c
+++ b/ptest/server_test.c
@@ -462,7 +462,6 @@ mu_test__verify_full_uint_bad5(void)
   verify_full_uint(5);
 }
 
-
 void
 test_server_merge(int bad)
 {
@@ -487,11 +486,12 @@ test_server_merge(int bad)
     mp_set(&cfg1->modulus, 6);
   }
   if (bad == 3) {
-    PT_CHECKA(cfg2 = PrioConfig_new(2, NULL, NULL, (const unsigned char*)"bad", 3));
+    PT_CHECKA(cfg2 =
+                PrioConfig_new(2, NULL, NULL, (const unsigned char*)"bad", 3));
   } else {
     PT_CHECKA(cfg2 = PrioConfig_newTest(2));
   }
-  
+
   PT_CHECKA(s1 = PrioServer_new(cfg1, 0, skA, seed));
   PT_CHECKA(s2 = PrioServer_new(cfg2, 0, skA, seed));
 

--- a/ptest/server_test.c
+++ b/ptest/server_test.c
@@ -507,6 +507,8 @@ test_server_merge(int bad)
 
 cleanup:
   mu_check(bad ? rv == SECFailure : rv == SECSuccess);
+  PublicKey_clear(pkA);
+  PrivateKey_clear(skA);
   PrioConfig_clear(cfg1);
   PrioConfig_clear(cfg2);
   PrioServer_clear(s1);

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,7 +43,7 @@ extension_mod = Extension(
 
 setup(
     name="prio",
-    version="1.0.3",
+    version="1.1",
     description="An interface to libprio",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/python/src/libprio.py
+++ b/python/src/libprio.py
@@ -138,6 +138,18 @@ def PrioTotalShare_final_uint(cfg, prec, tA, tB):
     return _libprio.PrioTotalShare_final_uint(cfg, prec, tA, tB)
 
 
+def PrioServer_write(p):
+    r"""
+    PrioServer_write(const_PrioServer p) -> PyObject *
+
+    Parameters
+    ----------
+    p: const_PrioServer
+
+    """
+    return _libprio.PrioServer_write(p)
+
+
 def PrioPacketVerify1_write(p):
     r"""
     PrioPacketVerify1_write(const_PrioPacketVerify1 p) -> PyObject *
@@ -172,6 +184,20 @@ def PrioTotalShare_write(p):
 
     """
     return _libprio.PrioTotalShare_write(p)
+
+
+def PrioServer_read(p, data, cfg):
+    r"""
+    PrioServer_read(PrioServer p, unsigned char const * data, const_PrioConfig cfg) -> SECStatus
+
+    Parameters
+    ----------
+    p: PrioServer
+    data: unsigned char const *
+    cfg: const_PrioConfig
+
+    """
+    return _libprio.PrioServer_read(p, data, cfg)
 
 
 def PrioPacketVerify1_read(p, data, cfg):
@@ -510,6 +536,19 @@ def PrioServer_aggregate(s, v):
 
     """
     return _libprio.PrioServer_aggregate(s, v)
+
+
+def PrioServer_merge(s, s_i):
+    r"""
+    PrioServer_merge(PrioServer s, const_PrioServer s_i) -> SECStatus
+
+    Parameters
+    ----------
+    s: PrioServer
+    s_i: const_PrioServer
+
+    """
+    return _libprio.PrioServer_merge(s, s_i)
 
 
 def PrioTotalShare_new():

--- a/python/swig/libprio.i
+++ b/python/swig/libprio.i
@@ -263,9 +263,11 @@ VERIFIER_SET_DATA()
 TOTAL_SHARE_FINAL()
 
 // depends on typemap defined in EXPORT_PYTHON_DATA
+MSGPACK_WRITE(PrioServer)
 MSGPACK_WRITE(PrioPacketVerify1)
 MSGPACK_WRITE(PrioPacketVerify2)
 MSGPACK_WRITE(PrioTotalShare)
+MSGPACK_READ(PrioServer)
 MSGPACK_READ(PrioPacketVerify1)
 MSGPACK_READ(PrioPacketVerify2)
 MSGPACK_READ(PrioTotalShare)

--- a/python/tests/test_libprio_foldable.py
+++ b/python/tests/test_libprio_foldable.py
@@ -1,0 +1,66 @@
+"""Aggregate encoded shares from multiple servers.
+
+In this case, we might think about a Prio service where disjoint sets of shares
+are distributed amongst a set of servers sharing the same configuration. We
+should be able to merge these aggregates together to obtain a correct result.
+"""
+import pytest
+from prio import PrioContext
+from prio.libprio import *
+import array
+
+
+@PrioContext()
+def test_server_merge():
+    seed = PrioPRGSeed_randomize()
+    skA, pkA = Keypair_new()
+    skB, pkB = Keypair_new()
+    batch_id = b"test_batch"
+    n_fields = 133
+    n_servers = 4
+    clients_per_server = {i: 2 ** i for i in range(n_servers)}
+
+    cfg = PrioConfig_new(n_fields, pkA, pkB, batch_id)
+    n_data = PrioConfig_numDataFields(cfg)
+    data_items = bytes([(i % 3 == 1) or (i % 5 == 1) for i in range(n_data)])
+
+    sA_serialized = []
+    sB_serialized = []
+
+    for i in range(n_servers):
+        sA = PrioServer_new(cfg, PRIO_SERVER_A, skA, seed)
+        sB = PrioServer_new(cfg, PRIO_SERVER_B, skB, seed)
+        vA = PrioVerifier_new(sA)
+        vB = PrioVerifier_new(sB)
+        for _ in range(clients_per_server[i]):
+            for_a, for_b = PrioClient_encode(cfg, data_items)
+            PrioVerifier_set_data(vA, for_a)
+            PrioVerifier_set_data(vB, for_b)
+            PrioServer_aggregate(sA, vA)
+            PrioServer_aggregate(sB, vB)
+        sA_serialized.append(PrioServer_write(sA))
+        sB_serialized.append(PrioServer_write(sB))
+
+    sA = PrioServer_new(cfg, PRIO_SERVER_A, skA, seed)
+    for data in sA_serialized:
+        sA_i = PrioServer_new(cfg, PRIO_SERVER_A, skA, seed)
+        PrioServer_read(sA_i, data, cfg)
+        PrioServer_merge(sA, sA_i)
+
+    sB = PrioServer_new(cfg, PRIO_SERVER_B, skB, seed)
+    for data in sB_serialized:
+        sB_i = PrioServer_new(cfg, PRIO_SERVER_B, skB, seed)
+        PrioServer_read(sB_i, data, cfg)
+        PrioServer_merge(sB, sB_i)
+
+    tA = PrioTotalShare_new()
+    tB = PrioTotalShare_new()
+    PrioTotalShare_set_data(tA, sA)
+    PrioTotalShare_set_data(tB, sB)
+
+    output = array.array("L", PrioTotalShare_final(cfg, tA, tB))
+
+    expected = [
+        item * sum(2 ** i for i in range(n_servers)) for item in list(data_items)
+    ]
+    assert list(output) == expected

--- a/python/tests/test_libprio_foldable.py
+++ b/python/tests/test_libprio_foldable.py
@@ -1,8 +1,8 @@
 """Aggregate encoded shares from multiple servers.
 
 In this case, we might think about a Prio service where disjoint sets of shares
-are distributed amongst a set of servers sharing the same configuration. We
-should be able to merge these aggregates together to obtain a correct result.
+are distributed among a set of servers sharing a common configuration. These
+aggregates should have the ability to be merged.
 """
 import pytest
 from prio import PrioContext
@@ -63,4 +63,59 @@ def test_server_merge():
     expected = [
         item * sum(2 ** i for i in range(n_servers)) for item in list(data_items)
     ]
+    assert list(output) == expected
+
+
+@PrioContext()
+def test_server_merge_uint():
+    seed = PrioPRGSeed_randomize()
+    skA, pkA = Keypair_new()
+    skB, pkB = Keypair_new()
+    batch_id = b"test_batch"
+    precision = 7
+    num_uint_entries = 11
+    n_servers = 4
+    clients_per_server = {i: 2 ** i for i in range(n_servers)}
+
+    cfg = PrioConfig_new_uint(num_uint_entries, precision, pkA, pkB, batch_id)
+    n_data = PrioConfig_numUIntEntries(cfg, precision)
+    data_items = bytes(array.array("L", [i for i in range(n_data)]))
+
+    sA_serialized = []
+    sB_serialized = []
+
+    for i in range(n_servers):
+        sA = PrioServer_new(cfg, PRIO_SERVER_A, skA, seed)
+        sB = PrioServer_new(cfg, PRIO_SERVER_B, skB, seed)
+        vA = PrioVerifier_new(sA)
+        vB = PrioVerifier_new(sB)
+        for _ in range(clients_per_server[i]):
+            for_a, for_b = PrioClient_encode_uint(cfg, precision, data_items)
+            PrioVerifier_set_data(vA, for_a)
+            PrioVerifier_set_data(vB, for_b)
+            PrioServer_aggregate(sA, vA)
+            PrioServer_aggregate(sB, vB)
+        sA_serialized.append(PrioServer_write(sA))
+        sB_serialized.append(PrioServer_write(sB))
+
+    sA = PrioServer_new(cfg, PRIO_SERVER_A, skA, seed)
+    for data in sA_serialized:
+        sA_i = PrioServer_new(cfg, PRIO_SERVER_A, skA, seed)
+        PrioServer_read(sA_i, data, cfg)
+        PrioServer_merge(sA, sA_i)
+
+    sB = PrioServer_new(cfg, PRIO_SERVER_B, skB, seed)
+    for data in sB_serialized:
+        sB_i = PrioServer_new(cfg, PRIO_SERVER_B, skB, seed)
+        PrioServer_read(sB_i, data, cfg)
+        PrioServer_merge(sB, sB_i)
+
+    tA = PrioTotalShare_new()
+    tB = PrioTotalShare_new()
+    PrioTotalShare_set_data_uint(tA, sA, precision)
+    PrioTotalShare_set_data_uint(tB, sB, precision)
+
+    output = array.array("Q", PrioTotalShare_final_uint(cfg, precision, tA, tB))
+
+    expected = [item * sum(2 ** i for i in range(n_servers)) for item in range(n_data)]
     assert list(output) == expected

--- a/python/tests/test_libprio_serialize.py
+++ b/python/tests/test_libprio_serialize.py
@@ -59,6 +59,14 @@ def _exchange_with_serialization():
     PrioServer_aggregate(sA, vA)
     PrioServer_aggregate(sB, vB)
 
+    sA_data = PrioServer_write(sA)
+    sB_data = PrioServer_write(sB)
+    sA = PrioServer_new(cfg, PRIO_SERVER_A, skA, server_secret)
+    sB = PrioServer_new(cfg, PRIO_SERVER_B, skB, server_secret)
+    PrioServer_read(sA, sA_data, cfg)
+    PrioServer_read(sB, sB_data, cfg)
+    yield "aggregate"
+
     # Collect from many clients and share data
     PrioTotalShare_set_data(tA, sA)
     PrioTotalShare_set_data(tB, sB)
@@ -91,8 +99,17 @@ def test_prio_packet_verify2_serialize():
 
 
 @PrioContext()
+def test_prio_aggregate_state_serialize():
+    exchange = _exchange_with_serialization()
+    assert "verify1" == next(exchange)
+    assert "verify2" == next(exchange)
+    assert "aggregate" == next(exchange)
+
+
+@PrioContext()
 def test_prio_packet_totalshare_serialize():
     exchange = _exchange_with_serialization()
     assert "verify1" == next(exchange)
     assert "verify2" == next(exchange)
+    assert "aggregate" == next(exchange)
     assert "totalshare" == next(exchange)


### PR DESCRIPTION
The current interface requires a long-lived pointer to a `PrioServer` structure. This makes it difficult to use the library when server state is distributed across several processes. This PR adds methods for server serialization and deserialization, as well as a method for merging the state of two server structures.