### PR TITLE
Build and publish linux wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,13 @@ addons:
     - libnss3-dev
     - clang-format-9
 
-script:
-  - scons DEBUG=1 SANITIZE=1
-  - ./build/ptest/ptest -vvv
+
+jobs:
+  include:
+    - stage: test
+      script:
+        - scons DEBUG=1 SANITIZE=1
+        - ./build/ptest/ptest -vvv
+
+stages:
+  - test

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -1,0 +1,43 @@
+FROM centos:8
+
+ENV LANG en_US.utf8
+
+RUN dnf install -y epel-release \
+    && dnf install -y \
+        which \
+        make \
+        gcc \
+        clang \
+        swig \
+        python36-devel \
+        python36 \
+        nss-devel \
+        msgpack-devel \
+    && dnf clean all
+
+# set a default python binary and install scons
+RUN alternatives --set python /usr/bin/python3
+RUN python -m pip install --upgrade pip && pip3 install scons pytest
+
+# symbolically link to name without version suffix for libprio
+RUN ln -s /usr/include/nspr4 /usr/include/nspr \
+    && ln -s /usr/include/nss3 /usr/include/nss
+
+RUN dnf install -y @development zlib-devel bzip2 bzip2-devel readline-devel sqlite \
+    sqlite-devel openssl-devel xz xz-devel libffi-devel findutils
+
+RUN curl https://pyenv.run | bash
+ENV PATH "/root/.pyenv/bin:$PATH"
+RUN pyenv install 3.7.8
+RUN pyenv install 3.8.3
+
+WORKDIR /app
+ADD . /app
+
+# first build the python wrapper with -fPIC
+WORKDIR /app/python
+RUN make
+
+RUN eval "$(pyenv init -)" && pyenv shell 3.8.3 && python setup.py bdist_wheel
+
+# libmsgpackc2 libnspr4 libnss3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,15 @@ services:
       context: .
       dockerfile: Dockerfile
     image: libprio:${TAG:-latest}
+  libprio-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: libprio:${TAG:-latest}
+    volumes:
+      - $PWD:/app
+  libprio-dist:
+    build:
+      context: .
+      dockerfile: Dockerfile.dist
+    image: libprio:dist


### PR DESCRIPTION
The build and release process for linux wheels can be done within this Docker container.

* Install pyenv and the relevant versions of Python (3.6, 3.7, 3.8)
* Build the binary wheel
* Distribute by uploading to pypi (or gcs)

I've done some initial testing by building the wheel in this centos container and running it in an ubuntu container. It might be worth considering TaskCluster for this use-case, but I am more familiar with CircleCI for multi-step workflows. @rhelmer do you have input on what CI service to use to build and distribute the wheels?