### PR TITLE
CI: unbreak FreeBSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       ./scripts/clang-format.sh;
     elif [[ "$TRAVIS_OS_NAME" = "freebsd" ]]; then
-      sudo pkg install -y scons msgpack nss;
+      sudo pkg install -y msgpack nss;
+      sudo pkg install -yx \^scons-py3;
     elif [[ "$TRAVIS_OS_NAME" = "osx" ]]; then
       brew update;
       brew upgrade nspr nss msgpack;


### PR DESCRIPTION
Regressed by https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=241463.
`/quarterly` (default on releases) package set was refreshed on 2020-07-07.

```
$ pkg search scons
scons-py27-3.1.2               Build tool alternative to make
scons-py37-3.1.2               Build tool alternative to make
```
