### PR TITLE
Add script to distribute binary wheels

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -1,36 +1,24 @@
-FROM centos:8
+FROM quay.io/pypa/manylinux2014_x86_64
 
 ENV LANG en_US.utf8
 
-RUN dnf install -y epel-release \
-    && dnf install -y \
+RUN yum install -y \
         which \
         make \
         gcc \
         clang \
         swig \
-        python36-devel \
-        python36 \
         nss-devel \
         msgpack-devel \
-    && dnf clean all
+    && yum clean all
 
 # set a default python binary and install scons
-RUN alternatives --set python /usr/bin/python3
-RUN python -m pip install --upgrade pip && pip3 install scons pytest
+ENV PATH=$PATH:/opt/python/cp38-cp38/bin
+RUN pip3 install scons pytest
 
 # symbolically link to name without version suffix for libprio
 RUN ln -s /usr/include/nspr4 /usr/include/nspr \
     && ln -s /usr/include/nss3 /usr/include/nss
-
-RUN dnf install -y @development zlib-devel bzip2 bzip2-devel readline-devel sqlite \
-    sqlite-devel openssl-devel xz xz-devel libffi-devel findutils
-
-RUN curl https://pyenv.run | bash
-ENV PATH "/root/.pyenv/bin:$PATH"
-RUN pyenv install 3.6.0
-RUN pyenv install 3.7.0
-RUN pyenv install 3.8.0
 
 WORKDIR /app
 ADD . /app

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -1,0 +1,43 @@
+FROM centos:8
+
+ENV LANG en_US.utf8
+
+RUN dnf install -y epel-release \
+    && dnf install -y \
+        which \
+        make \
+        gcc \
+        clang \
+        swig \
+        python36-devel \
+        python36 \
+        nss-devel \
+        msgpack-devel \
+    && dnf clean all
+
+# set a default python binary and install scons
+RUN alternatives --set python /usr/bin/python3
+RUN python -m pip install --upgrade pip && pip3 install scons pytest
+
+# symbolically link to name without version suffix for libprio
+RUN ln -s /usr/include/nspr4 /usr/include/nspr \
+    && ln -s /usr/include/nss3 /usr/include/nss
+
+RUN dnf install -y @development zlib-devel bzip2 bzip2-devel readline-devel sqlite \
+    sqlite-devel openssl-devel xz xz-devel libffi-devel findutils
+
+RUN curl https://pyenv.run | bash
+ENV PATH "/root/.pyenv/bin:$PATH"
+RUN pyenv install 3.7.8
+RUN pyenv install 3.8.3
+
+WORKDIR /app
+ADD . /app
+
+# first build the python wrapper with -fPIC
+WORKDIR /app/python
+RUN make
+
+RUN eval "$(pyenv init -)" && pyenv shell 3.8.3 && python setup.py bdist_wheel
+
+# libmsgpackc2 libnspr4 libnss3

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -28,8 +28,9 @@ RUN dnf install -y @development zlib-devel bzip2 bzip2-devel readline-devel sqli
 
 RUN curl https://pyenv.run | bash
 ENV PATH "/root/.pyenv/bin:$PATH"
-RUN pyenv install 3.7.8
-RUN pyenv install 3.8.3
+RUN pyenv install 3.6.0
+RUN pyenv install 3.7.0
+RUN pyenv install 3.8.0
 
 WORKDIR /app
 ADD . /app
@@ -38,6 +39,4 @@ ADD . /app
 WORKDIR /app/python
 RUN make
 
-RUN eval "$(pyenv init -)" && pyenv shell 3.8.3 && python setup.py bdist_wheel
-
-# libmsgpackc2 libnspr4 libnss3
+CMD /app/scripts/python-dist.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,15 @@ services:
       context: .
       dockerfile: Dockerfile
     image: libprio:${TAG:-latest}
+  libprio-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: libprio:${TAG:-latest}
+    volumes:
+      - $PWD:/app
+  libprio-dist:
+    build:
+      context: .
+      dockerfile: Dockerfile.dist
+    image: libprio:dist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,5 @@ services:
       context: .
       dockerfile: Dockerfile.dist
     image: libprio:dist
+    volumes:
+      - $PWD:/app

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/python/Makefile
+++ b/python/Makefile
@@ -10,6 +10,10 @@ all:
 install: all
 	pip3 install .
 
+dist: all
+	pip3 install wheel
+	python3 setup.py bdist_egg bdist_wheel
+
 format:
 	clang-format -style=Mozilla -i swig/libprio_wrap.c
 	black setup.py src tests

--- a/python/Makefile
+++ b/python/Makefile
@@ -35,3 +35,4 @@ clean:
 	rm -rf build
 	rm -rf libprio
 	rm -rf dist
+	rm -rf wheelhouse

--- a/python/Makefile
+++ b/python/Makefile
@@ -12,7 +12,7 @@ install: all
 
 dist: all
 	pip3 install wheel
-	python3 setup.py bdist_egg bdist_wheel
+	python3 setup.py bdist_wheel
 
 format:
 	clang-format -style=Mozilla -i swig/libprio_wrap.c

--- a/python/README.md
+++ b/python/README.md
@@ -28,9 +28,7 @@ and Linux. From the project root, run the following command to distribute the
 wheels for macOS.
 
 ```bash
-# optional: for testing
-export TWINE_REPOSITORY=testpypi
-
+export TWINE_REPOSITORY=testpypi  # optional: for testing
 export TWINE_USERNAME=__token__
 export TWINE_PASSWORD=<API_KEY>
 ./scripts/python-dist.sh
@@ -46,12 +44,12 @@ docker-compose run -e TWINE_USERNAME -e TWINE_PASSWORD libprio-dist
 ```
 
 The binary distributions can be tested from a variety of docker images, which
-are the primary target for use. Here is an example on an Ubuntu 20.04 image.
+are the primary target for use.
 
 ```bash
-docker run -it ubuntu:20.04 bash
-apt update && apt install python3 python3-pip libmsgpackc2 libnspr4 libnss3
-pip3 install -i https://test.pypi.org/simple/ prio
+docker run -it python:3 bash
+apt update && apt install libmsgpackc2 libnspr4 libnss3
+pip install prio
 python3 -c "from prio.libprio import *; Prio_init(); print(PrioPRGSeed_randomize())"
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -4,6 +4,41 @@ This module contains a Python wrapper around libprio.
 
 ## Quickstart
 
+Install the required dependencies via the system package manager and install the
+package from pip. The shared libraries for msgpack and NSS must be available for
+the module to initialize properly.
+
+On an image derived from Ubuntu:
+
+```bash
+docker run -it python:3 bash
+apt update && apt install libmsgpackc2 libnss3
+```
+
+On Centos:
+
+```bash
+docker run -it centos:8 bash
+dnf update && dnf install epel-release && dnf install python36 msgpack nss
+```
+
+On macOS:
+
+```bash
+brew install msgpack nss
+```
+
+To test the package:
+
+```bash
+pip3 install prio
+python3 -c "from prio.libprio import *; Prio_init(); print(PrioPRGSeed_randomize())"
+```
+
+## Building from source
+
+Ensure all of the libprio build tools are available, such as `scons` and `clang`
+
 ```python
 python3 -m venv venv
 source venv/bin/activate
@@ -21,7 +56,7 @@ pip install pytest-cov
 python -m pytest --cov-report=html --cov-report=term --cov=prio tests
 ```
 
-## Distribute
+## Distributing
 
 Binary eggs and wheels are built for Python 3.6, 3.7, and 3.8 for macOS 10.15
 and Linux. From the project root, run the following command to distribute the
@@ -41,16 +76,6 @@ docker-compose build libprio-dist
 export TWINE_USERNAME=__token__
 export TWINE_PASSWORD=<API_KEY>
 docker-compose run -e TWINE_USERNAME -e TWINE_PASSWORD libprio-dist
-```
-
-The binary distributions can be tested from a variety of docker images, which
-are the primary target for use.
-
-```bash
-docker run -it python:3 bash
-apt update && apt install libmsgpackc2 libnspr4 libnss3
-pip install prio
-python3 -c "from prio.libprio import *; Prio_init(); print(PrioPRGSeed_randomize())"
 ```
 
 ## Build Process

--- a/python/README.md
+++ b/python/README.md
@@ -21,6 +21,40 @@ pip install pytest-cov
 python -m pytest --cov-report=html --cov-report=term --cov=prio tests
 ```
 
+## Distribute
+
+Binary eggs and wheels are built for Python 3.6, 3.7, and 3.8 for macOS 10.15
+and Linux. From the project root, run the following command to distribute the
+wheels for macOS.
+
+```bash
+# optional: for testing
+export TWINE_REPOSITORY=testpypi
+
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD=<API_KEY>
+./scripts/python-dist.sh
+```
+
+Run the docker container for distributing the linux wheels.
+
+```bash
+docker-compose build libprio-dist
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD=<API_KEY>
+docker-compose run -e TWINE_USERNAME -e TWINE_PASSWORD libprio-dist
+```
+
+The binary distributions can be tested from a variety of docker images, which
+are the primary target for use. Here is an example on an Ubuntu 20.04 image.
+
+```bash
+docker run -it ubuntu:20.04 bash
+apt update && apt install python3 python3-pip libmsgpackc2 libnspr4 libnss3
+pip3 install -i https://test.pypi.org/simple/ prio
+python3 -c "from prio.libprio import *; Prio_init(); print(PrioPRGSeed_randomize())"
+```
+
 ## Build Process
 
 There are issues running an installation of the extension module inside of the

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,7 +43,7 @@ extension_mod = Extension(
 
 setup(
     name="prio",
-    version="1.0.2",
+    version="1.0.3",
     description="An interface to libprio",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,6 +8,11 @@ from os import path
 from sys import platform
 
 
+def readme():
+    with open("README.md") as fp:
+        return fp.read()
+
+
 # Add platform specific settings for building the extension module
 if platform == "darwin":
     # macOS
@@ -38,8 +43,10 @@ extension_mod = Extension(
 
 setup(
     name="prio",
-    version="1.0",
+    version="1.0.2",
     description="An interface to libprio",
+    long_description=readme(),
+    long_description_content_type="text/markdown",
     author="Anthony Miyaguchi",
     author_email="amiyaguchi@mozilla.com",
     url="https://github.com/mozilla/libprio",

--- a/scripts/python-dist.sh
+++ b/scripts/python-dist.sh
@@ -3,23 +3,24 @@
 #
 # INSTALL_PYTHON_ENV: install the corresponding python versions via pyenv
 # SKIP_UPLOAD: if set, do not run twine for uploading packages
+# SKIP_WHEEL: if set, do not upload wheels to pypi due to manylinux non-conformance
 #
 # https://twine.readthedocs.io/en/latest/#environment-variables
 # TWINE_USERNAME: e.g. __token__
 # TWINE_PASSWORD: Set this to the api token
 # TWINE_REPOSITORY: e.g. pypi or testpypi
-# TWINE_NON_INTERACTIVE: e.g. true
+# TWINE_NON_INTERACTIVE: e.g. 0
 
 set -e
 
-VERSIONS="
-    3.6.0 
-    3.7.0 
-    3.8.0
-"
+export TWINE_NON_INTERACTIVE=${TWINE_NON_INTERACTIVE:-true}
 INSTALL_PYTHON_ENV=${INSTALL_PYTHON_ENV:-false}
 SKIP_UPLOAD=${SKIP_UPLOAD:-false}
-TWINE_NON_INTERACTIVE=${TWINE_NON_INTERACTIVE:-true}
+VERSIONS="
+    3.6.0
+    3.7.0
+    3.8.0
+"
 
 function ensure_environment {
     # check pyenv exists and enable the shell
@@ -43,7 +44,7 @@ function ensure_environment {
     fi
 }
 
-function build_wheel {
+function build_dist {
     local version=$1
     pyenv shell "$version"
     pip install pytest scons
@@ -58,12 +59,15 @@ ensure_environment
 make clean
 
 for version in $VERSIONS; do
-    build_wheel "$version"
+    build_dist "$version"
 done
 ls dist
 
 if [[ $SKIP_UPLOAD == "false" ]]; then
     pyenv shell "3.8.0"
     pip install twine
+    # NOTE:the wheel is not manylinux compatible.
+    # > Binary wheel 'prio-1.0-cp36-cp36m-linux_x86_64.whl' has an unsupported platform tag 'linux_x86_64'.
+    # TODO: lie about being manylinux1 compliant, and note this in the README
     twine upload --skip-existing "dist/*"
 fi

--- a/scripts/python-dist.sh
+++ b/scripts/python-dist.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Build binary wheels of prio and upload them to pypi.
+#
+# INSTALL_PYTHON_ENV: install the corresponding python versions via pyenv
+# SKIP_UPLOAD: if set, do not run twine for uploading packages
+#
+# https://twine.readthedocs.io/en/latest/#environment-variables
+# TWINE_USERNAME: e.g. __token__
+# TWINE_PASSWORD: Set this to the api token
+# TWINE_REPOSITORY: e.g. pypi or testpypi
+# TWINE_NON_INTERACTIVE: e.g. true
+
+set -e
+
+VERSIONS="
+    3.6.0 
+    3.7.0 
+    3.8.0
+"
+INSTALL_PYTHON_ENV=${INSTALL_PYTHON_ENV:-false}
+SKIP_UPLOAD=${SKIP_UPLOAD:-false}
+TWINE_NON_INTERACTIVE=${TWINE_NON_INTERACTIVE:-true}
+
+function ensure_environment {
+    # check pyenv exists and enable the shell
+    pyenv --version
+    eval "$(pyenv init -)"
+
+    if [[ $INSTALL_PYTHON_ENV != "false" ]]; then
+        for version in $VERSIONS; do
+            pyenv install $version --skip-existing
+        done
+    fi
+    local error=0
+    for version in $VERSIONS; do
+        if ! pyenv shell "$version"; then
+            error=$((error + 1))
+        fi
+    done
+    pyenv shell system
+    if ((error > 0)); then
+        echo "missing installation of python versions"
+    fi
+}
+
+function build_wheel {
+    local version=$1
+    pyenv shell "$version"
+    pip install pytest scons
+    make install
+    python -m pytest tests -v
+    make dist
+}
+
+cd "$(dirname "$0")/../python"
+
+ensure_environment
+make clean
+
+for version in $VERSIONS; do
+    build_wheel "$version"
+done
+ls dist
+
+if [[ $SKIP_UPLOAD == "false" ]]; then
+    pyenv shell "3.8.0"
+    pip install twine
+    twine upload --skip-existing "dist/*"
+fi

--- a/scripts/python-dist.sh
+++ b/scripts/python-dist.sh
@@ -36,7 +36,7 @@ function ensure_pyenv() {
 }
 
 function build_dist() {
-    pip install pytest scons
+    pip install --upgrade setuptools scons pytest
     make install
     python -m pytest tests -v
     make dist
@@ -59,11 +59,11 @@ function manylinux_main {
     done
     mkdir wheelhouse
     for wheel in dist/*.whl; do
-        # Retag the binary wheel as manylinux2014 for acceptance into pypi,
+        # Retag the binary wheel as manylinux1 for acceptance into pypi,
         # however this is not actually manylinux compatible. Note that
         # `auditwheel repair` will cause Prio_init due to NSS incompatibilities.
         # auditwheel repair "$wheel"
-        cp "$wheel" wheelhouse/"$(basename "${wheel/-linux_/-manylinux2014_}")"
+        cp "$wheel" wheelhouse/"$(basename "${wheel/-linux_/-manylinux1_}")"
     done;
 }
 


### PR DESCRIPTION
This PR adds the ability to distribute binary wheels for use in macOS and Linux. The `scripts/python-dist.sh` script will generate wheels for supported Python versions and upload them to pypi. The [uploaded package for `prio==1.0.3` can be tested from testpypi](https://test.pypi.org/project/prio/1.0.3/).

```bash
docker run -it python:3 bash
apt update && apt install libmsgpackc2 libnss3
pip3 install -i https://test.pypi.org/simple/ prio==1.0.3
python3 -c "from prio.libprio import *; Prio_init(); print(PrioPRGSeed_randomize())"
```

This should work in most environments where it would be useful to run Prio (e.g. a Dataproc or EMR cluster). There are some caveats here:

* The deployment process is manual. Adding this to CI is doable, but it requires some setup. It is easier to manually push new packages when updates are merged.
* The macOS deployment script uses pyenv, which can be slow to download and install.
* The linux wheels are not actually [`manylinux1` (PEP-513) compatible](https://www.python.org/dev/peps/pep-0513/). This is due to the reliance on NSS, which does not play well with `auditwheel repair`. Attempting to use a wheel that includes a copy of the shares libraries from the `manylinux2014` docker container will fail to initialize.


