### PR TITLE
Added fixed point encoding

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -88,6 +88,7 @@ Export("env")
 SConscript("mpi/SConscript", variant_dir="build/mpi")
 SConscript("pclient/SConscript", variant_dir="build/pclient")
 SConscript("pclient_uint/SConscript", variant_dir="build/pclient_uint")
+SConscript("pclient_fp/SConscript", variant_dir="build/pclient_fp")
 SConscript("prio/SConscript", variant_dir="build/prio")
 SConscript("ptest/SConscript", variant_dir="build/ptest")
 

--- a/pclient_fp/SConscript
+++ b/pclient_fp/SConscript
@@ -1,0 +1,18 @@
+import sys
+
+Import('env')
+
+prio_env = env.Clone()
+
+src = [
+    "main.c",
+]
+
+libs = [
+  "mprio",
+  "msgpackc",
+]
+
+prio_env.Append(LIBS = libs)
+prio_env.Program("pclient_fp", src)
+

--- a/pclient_fp/main.c
+++ b/pclient_fp/main.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2018, Henry Corrigan-Gibbs
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <mprio.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "prio/util.h"
+
+int
+verify_full(void)
+{
+  SECStatus rv = SECSuccess;
+
+  PublicKey pkA = NULL;
+  PublicKey pkB = NULL;
+  PrivateKey skA = NULL;
+  PrivateKey skB = NULL;
+
+  PrioConfig cfg = NULL;
+  PrioServer sA = NULL;
+  PrioServer sB = NULL;
+  PrioVerifier vA = NULL;
+  PrioVerifier vB = NULL;
+  PrioPacketVerify1 p1A = NULL;
+  PrioPacketVerify1 p1B = NULL;
+  PrioPacketVerify2 p2A = NULL;
+  PrioPacketVerify2 p2B = NULL;
+  PrioTotalShare tA = NULL;
+  PrioTotalShare tB = NULL;
+
+  unsigned char* for_server_a = NULL;
+  unsigned char* for_server_b = NULL;
+
+  const unsigned char* batch_id = (unsigned char*)"prio_batch_2018-04-17";
+  const unsigned int batch_id_len = strlen((char*)batch_id);
+
+  unsigned long long* output_uint = NULL;
+  long double* output_fp = NULL;
+  float* data_items = NULL;
+
+  // Initialize NSS random number generator.
+  P_CHECKC(Prio_init());
+
+  // Number of different fixed point data fields we collect.
+  const int ndata = 100;
+
+  // Set parameters for a Q10.11 fixed point. See
+  // https://en.wikipedia.org/wiki/Q_(number_format) for a
+  // description.
+  // Precision of integer part for each fixed point entry.
+  const int ibits = 10;
+  // Precision of fractional part for each fixed point entry.
+  const int fbits = 11;
+  // For compatibility reasons ibits and fbits are not contained in
+  // PrioConfig and must be set client- and serverside.
+
+  // Number of clients to simulate.
+  const int nclients = 10;
+
+  P_CHECKA(output_uint = calloc(ndata, sizeof(unsigned long long)));
+  P_CHECKA(output_fp = calloc(ndata, sizeof(long double)));
+  P_CHECKA(data_items = calloc(ndata, sizeof(float)));
+
+  // Generate keypairs for servers
+  P_CHECKC(Keypair_new(&skA, &pkA));
+  P_CHECKC(Keypair_new(&skB, &pkB));
+
+  // Use the default configuration parameters.
+  P_CHECKA(cfg = PrioConfig_new_fp(
+             ndata, ibits, fbits, pkA, pkB, batch_id, batch_id_len));
+
+  PrioPRGSeed server_secret;
+  P_CHECKC(PrioPRGSeed_randomize(&server_secret));
+
+  // Initialize two server objects. The role of the servers need not
+  // be symmetric. In a deployment, we envision that:
+  //   * Server A is the main telemetry server that is always online.
+  //     Clients send their encrypted data packets to Server A and
+  //     Server A stores them.
+  //   * Server B only comes online when the two servers want to compute
+  //     the final aggregate statistics.
+  P_CHECKA(sA = PrioServer_new(cfg, PRIO_SERVER_A, skA, server_secret));
+  P_CHECKA(sB = PrioServer_new(cfg, PRIO_SERVER_B, skB, server_secret));
+
+  // Initialize empty verifier objects
+  P_CHECKA(vA = PrioVerifier_new(sA));
+  P_CHECKA(vB = PrioVerifier_new(sB));
+
+  // Initialize shares of final aggregate statistics
+  P_CHECKA(tA = PrioTotalShare_new());
+  P_CHECKA(tB = PrioTotalShare_new());
+
+  // Initialize shares of verification packets
+  P_CHECKA(p1A = PrioPacketVerify1_new());
+  P_CHECKA(p1B = PrioPacketVerify1_new());
+  P_CHECKA(p2A = PrioPacketVerify2_new());
+  P_CHECKA(p2B = PrioPacketVerify2_new());
+
+  float max = PrioConfig_FPMax(ibits, fbits);
+  float min = -PrioConfig_FPMax(ibits, fbits);
+
+  // Generate client data packets.
+  for (int c = 0; c < nclients; c++) {
+
+    // The client's data submission is an arbitrary float vector,
+    // which gets encoded as a fixed point number.
+    // PrioConfig_FPMax(ibits, fbits) returns its maximum value,
+    // PrioConfig_FPEps(fbits) its resolution. Each float is rounded
+    // to the next step resolution step toward zero.
+
+    // Arbitrary data
+    for (int i = 0; i < (int)(ndata / 2); i++) {
+      data_items[i] = max - (0.3 * i);
+    }
+    for (int i = (int)(ndata / 2); i < ndata; i++) {
+      data_items[i] = min + (0.3 * i);
+    }
+
+    // I. CLIENT DATA SUBMISSION.
+    //
+    // Construct the client data packets.
+    unsigned int aLen, bLen;
+    P_CHECKC(PrioClient_encode_fp(cfg,
+                                  ibits,
+                                  fbits,
+                                  data_items,
+                                  &for_server_a,
+                                  &aLen,
+                                  &for_server_b,
+                                  &bLen));
+
+    // The Prio servers A and B can come online later (e.g., at the end of
+    // each day) to download the encrypted telemetry packets from the
+    // telemetry server and run the protocol that computes the aggregate
+    // statistics. In this way, the client only needs to send a
+    // single message (the pair of encrypted ClientPacketData packets)
+    // to a single server (the telemetry-data-collection server).
+
+    // THE CLIENT'S JOB IS DONE. The rest of the processing just takes place
+    // between the two servers A and B.
+
+    // II. VALIDATION PROTOCOL. (at servers)
+    //
+    // The servers now run a short 2-step protocol to check each
+    // client's packet:
+    //    1) Servers A and B broadcast one message (PrioPacketVerify1)
+    //       to each other.
+    //    2) Servers A and B broadcast another message (PrioPacketVerify2)
+    //       to each other.
+    //    3) Servers A and B can both determine whether the client's data
+    //       submission is well-formed (in which case they add it to their
+    //       running total of aggregate statistics) or ill-formed
+    //       (in which case they ignore it).
+    // These messages must be sent over an authenticated channel, so
+    // that each server is assured that every received message came
+    // from its peer.
+
+    // Set up a Prio verifier object.
+    P_CHECKC(PrioVerifier_set_data(vA, for_server_a, aLen));
+    P_CHECKC(PrioVerifier_set_data(vB, for_server_b, bLen));
+
+    // Both servers produce a packet1. Server A sends p1A to Server B
+    // and vice versa.
+    P_CHECKC(PrioPacketVerify1_set_data(p1A, vA));
+    P_CHECKC(PrioPacketVerify1_set_data(p1B, vB));
+
+    // Both servers produce a packet2. Server A sends p2A to Server B
+    // and vice versa.
+    P_CHECKC(PrioPacketVerify2_set_data(p2A, vA, p1A, p1B));
+    P_CHECKC(PrioPacketVerify2_set_data(p2B, vB, p1A, p1B));
+
+    // Using p2A and p2B, the servers can determine whether the request
+    // is valid. (In fact, only Server A needs to perform this
+    // check, since Server A can just tell Server B whether the check
+    // succeeded or failed.)
+    P_CHECKC(PrioVerifier_isValid(vA, p2A, p2B));
+    P_CHECKC(PrioVerifier_isValid(vB, p2A, p2B));
+
+    // If we get here, the client packet is valid, so add it to the aggregate
+    // statistic counter for both servers.
+    P_CHECKC(PrioServer_aggregate(sA, vA));
+    P_CHECKC(PrioServer_aggregate(sB, vB));
+
+    free(for_server_a);
+    free(for_server_b);
+    for_server_a = NULL;
+    for_server_b = NULL;
+
+    // The servers repeat the steps above for each client submission.
+
+    // III. PRODUCTION OF AGGREGATE STATISTICS.
+    //
+    // After collecting aggregates from MANY clients, the servers can compute
+    // their shares of the aggregate statistics.
+    //
+    // Server B can send tB to Server A.
+    P_CHECKC(PrioTotalShare_set_data_fp(tA, sA, ibits, fbits));
+    P_CHECKC(PrioTotalShare_set_data_fp(tB, sB, ibits, fbits));
+
+    // Once Server A has tA and tB, it can learn the aggregate statistics
+    // in the clear.
+    P_CHECKC(PrioTotalShare_final_fp(
+      cfg, ibits, fbits, (c + 1), output_uint, output_fp, tA, tB));
+
+    // Now output_fp[i] contains the sum of floats (rounded to fixed
+    // point resolution) that clients submitted. We print these values.
+    for (int i = 0; i < ndata; i++)
+      printf("output[%d] = %.40Lg\n", i, output_fp[i]);
+  }
+
+cleanup:
+  if (rv != SECSuccess) {
+    fprintf(stderr, "Warning: unexpected failure.\n");
+  }
+
+  if (for_server_a)
+    free(for_server_a);
+  if (for_server_b)
+    free(for_server_b);
+  if (output_uint)
+    free(output_uint);
+  if (output_fp)
+    free(output_fp);
+  if (data_items)
+    free(data_items);
+
+  PrioTotalShare_clear(tA);
+  PrioTotalShare_clear(tB);
+
+  PrioPacketVerify2_clear(p2A);
+  PrioPacketVerify2_clear(p2B);
+
+  PrioPacketVerify1_clear(p1A);
+  PrioPacketVerify1_clear(p1B);
+
+  PrioVerifier_clear(vA);
+  PrioVerifier_clear(vB);
+
+  PrioServer_clear(sA);
+  PrioServer_clear(sB);
+  PrioConfig_clear(cfg);
+
+  PublicKey_clear(pkA);
+  PublicKey_clear(pkB);
+
+  PrivateKey_clear(skA);
+  PrivateKey_clear(skB);
+
+  Prio_clear();
+
+  return !(rv == SECSuccess);
+}
+
+int
+main(void)
+{
+  puts("This utility demonstrates how to invoke the Prio API for fixed point "
+       "vectors.");
+  return verify_full();
+}

--- a/prio/config.c
+++ b/prio/config.c
@@ -33,6 +33,18 @@ PrioConfig_maxUIntEntries(int prec)
   return PrioConfig_maxDataFields() / prec;
 }
 
+int
+PrioConfig_maxFPEntries(int ibits, int fbits)
+{
+  return PrioConfig_maxDataFields() / PrioConfig_FPReqPrec(ibits, fbits);
+}
+
+int
+PrioConfig_FPReqPrec(int ibits, int fbits)
+{
+  return (ibits + fbits) * 2;
+}
+
 PrioConfig
 PrioConfig_new(int n_fields,
                PublicKey server_a,
@@ -99,6 +111,28 @@ PrioConfig_new_uint(int num_uints,
 }
 
 PrioConfig
+PrioConfig_new_fp(int num_fp,
+                  int ibits,
+                  int fbits,
+                  PublicKey server_a,
+                  PublicKey server_b,
+                  const unsigned char* batch_id,
+                  unsigned int batch_id_len)
+{
+  if (ibits + fbits <= 0)
+    return NULL;
+  if (ibits + fbits > FPBITS_MAX)
+    return NULL;
+
+  return PrioConfig_new_uint(num_fp,
+                             PrioConfig_FPReqPrec(ibits, fbits),
+                             server_a,
+                             server_b,
+                             batch_id,
+                             batch_id_len);
+}
+
+PrioConfig
 PrioConfig_newTest(int nFields)
 {
   return PrioConfig_new(nFields, NULL, NULL, (unsigned char*)"testBatch", 9);
@@ -131,6 +165,41 @@ PrioConfig_numUIntEntries(const_PrioConfig cfg, int prec)
   if (prec > BBIT_PREC_MAX)
     return 0;
   return cfg->num_data_fields / prec;
+}
+
+int
+PrioConfig_numFPEntries(const_PrioConfig cfg, int ibits, int fbits)
+{
+  if (ibits + fbits < 1)
+    return 0;
+  if (ibits + fbits > FPBITS_MAX)
+    return 0;
+  return cfg->num_data_fields / PrioConfig_FPReqPrec(ibits, fbits);
+}
+
+int
+PrioConfig_FPQOne(int fbits)
+{
+  return (1 << fbits);
+}
+
+int
+PrioConfig_FPMBias(int ibits, int fbits)
+{
+  return (1 << (ibits + fbits));
+}
+
+float
+PrioConfig_FPEps(int fbits)
+{
+  return (1 / (float)PrioConfig_FPQOne(fbits));
+}
+
+float
+PrioConfig_FPMax(int ibits, int fbits)
+{
+  int max_int = (1l << ibits) - 1;
+  return max_int + (1 - PrioConfig_FPEps(fbits));
 }
 
 SECStatus

--- a/ptest/client_test.c
+++ b/ptest/client_test.c
@@ -8,6 +8,12 @@
 
 #include <mprio.h>
 
+// Needed for NAN, INFINITY, nextafterf()
+#include <math.h>
+
+// Needed for FLT_MAX
+#include <float.h>
+
 #include "mutest.h"
 #include "prio/client.c"
 #include "prio/client.h"
@@ -538,4 +544,566 @@ void
 mu_test_client__agg_wrong_server_prec(void)
 {
   test_client_agg_uint(10, 32, 133, true, 1);
+}
+
+// compute q_one and fp_eps for testing purposes
+float
+eps_step(int fbits, int i)
+{
+  long q_one = (1l << fbits);
+  float fp_eps = 1 / (float)q_one;
+
+  return fp_eps * i;
+}
+
+long
+eps_num(int ibits, int fbits)
+{
+  return (ibits + 1) * PrioConfig_FPQOne(fbits);
+}
+
+// Test wether rounding to resolution steps works correctly and wether
+// they are corretly ordered.
+void
+check_order_fp_encodings(int ibits, int fbits)
+{
+  SECStatus rv = SECSuccess;
+
+  // Calculate the following constants explicitly for testing purposes.
+  long q_one = (1l << fbits);
+  PT_CHECKCB(q_one == PrioConfig_FPQOne(fbits));
+
+  long m_bias = (1l << (ibits + fbits));
+  PT_CHECKCB(m_bias == PrioConfig_FPMBias(ibits, fbits));
+
+  // The resolution of our fixed point encoding
+  float fp_eps = 1 / (float)q_one;
+  PT_CHECKCB(fp_eps == PrioConfig_FPEps(fbits));
+
+  // The maximum positive value of the integer part
+  long max_int = (1l << ibits) - 1;
+
+  // Maximum representable value of our fixed point encoding,
+  // end of testing range
+  float max = max_int + (1 - fp_eps);
+  PT_CHECKCB(max == PrioConfig_FPMax(ibits, fbits));
+
+  // Input floats and decoded results
+  float cur, revert_p, revert_n;
+
+  // Rounding bounds for a given range
+  float lower_bound, upper_bound, next_upper_bound;
+
+  // Buffer for fixed point encoded floats (as long)
+  long dst_p = 0;
+  long dst_n = 0;
+
+  // Start test here
+  cur = 0;
+  long step = 0;
+
+  /*
+   *  -eps*3  -eps*2  -eps*1    0     eps*1   eps*2   eps*3
+   *    |-------|-------|-------|-------|-------|-------|
+   *               ^                         ^
+   *             -cur                      +cur
+   *
+   * The fixed point encoding for any given float will always be the
+   * closest resolution step towards 0, independent of where in this
+   * range it lies. In the above case, +cur would be encoded as eps*1
+   * and -cur as -eps*1.
+   *
+   * In the test below we check wether this is the case.
+   */
+  while (max > cur) {
+    // Increment cur to the next positive representable floating point number
+    cur = nextafterf(cur, max);
+
+    // Encode float as long
+    P_CHECKC(float_to_long(&dst_p, cur, ibits, fbits));
+    P_CHECKC(float_to_long(&dst_n, -cur, ibits, fbits));
+
+    // Decode long to float
+    revert_p = (dst_p - (double)m_bias) / q_one;
+    revert_n = (dst_n - (double)m_bias) / q_one;
+
+    // Compute bounds
+    lower_bound = eps_step(fbits, step);
+    upper_bound = eps_step(fbits, step + 1);
+    next_upper_bound = eps_step(fbits, step + 2);
+
+    // Check wether bounds are in the right order.
+    P_CHECKCB(lower_bound < upper_bound);
+    P_CHECKCB(upper_bound < next_upper_bound);
+    // NOTE: These checks fail if (ibits + bits) > 24, since the
+    // mantissa of a float has 24 bit precision, which makes 16777215
+    // the largest int that can be precisely represented with a float,
+    // but since FPBITS_MAX is 21 this is not an issue.
+
+    if ((cur >= lower_bound) && (cur < upper_bound)) {
+      // If cur is between two resolution steps, check if it rounds
+      // correctly.
+      P_CHECKCB(revert_p == lower_bound);
+      P_CHECKCB(revert_n == -lower_bound);
+    } else if ((cur >= upper_bound) && (cur < next_upper_bound)) {
+      // If cur is not in between the current two steps, but between
+      // the next two, check if it rounds correctly and increment the
+      // interval counter.
+      P_CHECKCB(revert_p == upper_bound);
+      P_CHECKCB(revert_n == -upper_bound);
+      step++;
+    } else {
+      // Fail if cur is neither in the current, nor the next interval.
+      P_CHECKCB(false);
+    }
+
+    // NOTE: We use P_CHECKCB in the loop since mu_check uses an int counter for
+    // checks and would overflow.
+  }
+
+cleanup:
+  mu_check(rv == SECSuccess);
+}
+
+// Test wether a sample of floats outside of the permissible range
+// gets correctly rejected.
+void
+reject_large_small(void)
+{
+  SECStatus rv = SECSuccess;
+  float max = FLT_MAX;
+  float min = PrioConfig_FPMax(15, 6) + PrioConfig_FPEps(6);
+  float cur = min;
+
+  long dst;
+  long i = 0;
+
+  while (cur < max) {
+    cur = nextafterf(cur, max);
+    if (i % 10000) {
+      P_CHECKCB(float_to_long(&dst, cur, 15, 6) == SECFailure);
+      P_CHECKCB(float_to_long(&dst, -cur, 15, 6) == SECFailure);
+    }
+    i++;
+  }
+
+cleanup:
+  mu_check(rv == SECSuccess);
+}
+
+void
+reject_nan_inf(void)
+{
+#ifdef NAN
+  long dst1;
+
+  SECStatus rv1 = float_to_long(&dst1, NAN, 10, 11);
+
+  mu_check(rv1 == SECFailure);
+#endif
+
+#ifdef INFINITY
+  long dst2;
+
+  SECStatus rv2 = float_to_long(&dst2, -INFINITY, 10, 11);
+  SECStatus rv3 = float_to_long(&dst2, INFINITY, 10, 11);
+
+  mu_check((rv2 == SECFailure) && (rv3 == SECFailure));
+#endif
+}
+
+// FLT_RADIX != 2 should not happen in binary floating-point
+// environments
+void
+float_radix(void)
+{
+  mu_check(FLT_RADIX == 2);
+}
+
+// Check wether a long double fits enough FPMAX_BITS submissions
+void
+long_double_size(void)
+{
+  mu_check(LDBL_MAX >= ((2 ^ BBIT_PREC_MAX) - 1) * FLT_MAX);
+}
+
+// Produces a representative sample of size (slice * 6)
+void
+gen_valid_fp_sample(int ibits, int fbits, int slice, float* sample)
+{
+  long max_i = eps_num(ibits, fbits);
+
+  // Small positive fps, including 0
+  for (int i = 0; i < slice; i++) {
+    sample[i] = eps_step(fbits, i);
+  }
+
+  // Small negative fps, including -0
+  for (int i = 0; i < slice; i++) {
+    sample[i + slice] = -eps_step(fbits, i);
+  }
+
+  // Large positive fps (including fp_max)
+  for (int i = 0; i < slice; i++) {
+    sample[i + (slice * 2)] = eps_step(fbits, (max_i - i));
+  }
+
+  // Large negative fps (including -fp_max)
+  for (int i = 0; i < slice; i++) {
+    sample[i + (slice * 3)] = -eps_step(fbits, (max_i - i));
+  }
+
+  // Midrange positive fps
+  for (int i = (slice * 4); i < (slice * 5); i++) {
+    sample[i] = eps_step(fbits, ((max_i / 2) + i));
+  }
+
+  // Midrange negative fps
+  for (int i = (slice * 5); i < (slice * 6); i++) {
+    sample[i] = -eps_step(fbits, ((max_i / 2) + i));
+  }
+}
+
+// Test wether resolution steps get properly en- and decode as longs
+// tweak 0, 2, 3 succeed; 1, fails
+void
+test_client_encode_decode_eps_steps(int nclients,
+                                    int ibits,
+                                    int fbits,
+                                    int slice,
+                                    bool config_is_okay,
+                                    int tweak)
+{
+  SECStatus rv = SECSuccess;
+  PublicKey pkA = NULL;
+  PublicKey pkB = NULL;
+  PrivateKey skA = NULL;
+  PrivateKey skB = NULL;
+  PrioConfig cfg = NULL;
+  PrioServer sA = NULL;
+  PrioServer sB = NULL;
+  PrioTotalShare tA = NULL;
+  PrioTotalShare tB = NULL;
+  PrioVerifier vA = NULL;
+  PrioVerifier vB = NULL;
+  unsigned char* for_a = NULL;
+  unsigned char* for_b = NULL;
+  const unsigned char* batch_id = (unsigned char*)"test_batch";
+  unsigned int batch_id_len = strlen((char*)batch_id);
+  float* data_items = NULL;
+  unsigned long long* output_uint = NULL;
+  long double* output_fp = NULL;
+
+  int num_fp_entries;
+
+  if ((tweak == 2) || (tweak == 3) || (tweak == 5)) {
+    num_fp_entries = slice;
+  } else {
+    num_fp_entries = 6 * slice;
+  }
+
+  PrioPRGSeed seed;
+  PT_CHECKC(PrioPRGSeed_randomize(&seed));
+
+  PT_CHECKC(Keypair_new(&skA, &pkA));
+  PT_CHECKC(Keypair_new(&skB, &pkB));
+  P_CHECKA(cfg = PrioConfig_new_fp(
+             num_fp_entries, ibits, fbits, pkA, pkB, batch_id, batch_id_len));
+  if (!config_is_okay) {
+    PT_CHECKCB(
+      (PrioConfig_new_fp(
+         num_fp_entries, ibits, fbits, pkA, pkB, batch_id, batch_id_len) ==
+       NULL));
+  }
+  PT_CHECKA(sA = PrioServer_new(cfg, 0, skA, seed));
+  PT_CHECKA(sB = PrioServer_new(cfg, 1, skB, seed));
+  PT_CHECKA(tA = PrioTotalShare_new());
+  PT_CHECKA(tB = PrioTotalShare_new());
+  PT_CHECKA(vA = PrioVerifier_new(sA));
+  PT_CHECKA(vB = PrioVerifier_new(sB));
+
+  PT_CHECKCB((PrioConfig_numFPEntries(cfg, ibits, fbits) >= num_fp_entries));
+
+  PT_CHECKA(data_items = calloc(num_fp_entries, sizeof(float)));
+  PT_CHECKA(output_uint = calloc(num_fp_entries, sizeof(unsigned long)));
+  PT_CHECKA(output_fp = calloc(num_fp_entries, sizeof(long double)));
+
+  if (tweak == 2) {
+    data_items[0] = PrioConfig_FPMax(ibits, fbits);
+  } else if (tweak == 3) {
+    data_items[0] = -PrioConfig_FPMax(ibits, fbits);
+  } else if (tweak == 5) {
+    data_items[0] = -PrioConfig_FPMax(ibits, fbits);
+    data_items[1] = PrioConfig_FPMax(ibits, fbits);
+    data_items[2] = PrioConfig_FPEps(fbits);
+    data_items[3] = -PrioConfig_FPEps(fbits);
+  } else {
+    // Data sample
+    gen_valid_fp_sample(ibits, fbits, 15, data_items);
+  }
+
+  for (int c = 0; c < nclients; c++) {
+    unsigned int aLen, bLen;
+    // Fail on tweak 2 and 3 cause values > max and < -max get passed
+    P_CHECKC(PrioClient_encode_fp(
+      cfg, ibits, fbits, data_items, &for_a, &aLen, &for_b, &bLen));
+
+    PT_CHECKC(PrioVerifier_set_data(vA, for_a, aLen));
+    PT_CHECKC(PrioVerifier_set_data(vB, for_b, bLen));
+
+    mu_check(PrioServer_aggregate(sA, vA) == SECSuccess);
+    mu_check(PrioServer_aggregate(sB, vB) == SECSuccess);
+
+    free(for_a);
+    free(for_b);
+
+    for_a = NULL;
+    for_b = NULL;
+
+    // Simulate mismatch between client and server config
+    if (tweak == 1) {
+      P_CHECKC(PrioTotalShare_set_data_fp(tA, sA, ibits + 1, fbits));
+      P_CHECKC(PrioTotalShare_set_data_fp(tB, sB, ibits + 1, fbits));
+    } else {
+      mu_check(PrioTotalShare_set_data_fp(tA, sA, ibits, fbits) == SECSuccess);
+      mu_check(PrioTotalShare_set_data_fp(tB, sB, ibits, fbits) == SECSuccess);
+    }
+
+    mu_check(PrioTotalShare_final_fp(
+               cfg, ibits, fbits, (c + 1), output_uint, output_fp, tA, tB) ==
+             SECSuccess);
+
+    if (tweak == 2) {
+      double v = PrioConfig_FPMax(ibits, fbits);
+      mu_check(output_fp[0] == v * (c + 1));
+    } else if (tweak == 3) {
+      double v = -PrioConfig_FPMax(ibits, fbits);
+      mu_check(output_fp[0] == v * (c + 1));
+    } else {
+      for (int i = 0; i < num_fp_entries; i++) {
+        double v = data_items[i];
+        mu_check(output_fp[i] == v * (c + 1));
+      }
+    }
+  }
+
+cleanup:
+  if ((tweak == 0) || (tweak == 2) || (tweak == 3) || (tweak == 5)) {
+    if (config_is_okay) {
+      mu_check(rv == SECSuccess);
+    } else {
+      mu_check(rv == SECFailure);
+    }
+  } else {
+    mu_check(rv == SECFailure);
+  }
+
+  if (data_items)
+    free(data_items);
+  if (output_uint)
+    free(output_uint);
+  if (output_fp)
+    free(output_fp);
+  if (for_a)
+    free(for_a);
+  if (for_b)
+    free(for_b);
+
+  PublicKey_clear(pkA);
+  PublicKey_clear(pkB);
+  PrivateKey_clear(skA);
+  PrivateKey_clear(skB);
+
+  PrioVerifier_clear(vA);
+  PrioVerifier_clear(vB);
+
+  PrioTotalShare_clear(tA);
+  PrioTotalShare_clear(tB);
+
+  PrioServer_clear(sA);
+  PrioServer_clear(sB);
+  PrioConfig_clear(cfg);
+}
+
+// Maximal fractional precision
+void
+mu_test_client__fp_round_all_floats_1(void)
+{
+  check_order_fp_encodings(0, 21);
+}
+
+// Maximal integer precision
+void
+mu_test_client__fp_round_all_floats_2(void)
+{
+  check_order_fp_encodings(21, 0);
+}
+
+// Mininimal fractional precision
+void
+mu_test_client__fp_round_all_floats_3(void)
+{
+  check_order_fp_encodings(0, 1);
+}
+
+// Mininimal integer precision
+void
+mu_test_client__fp_round_all_floats_4(void)
+{
+  check_order_fp_encodings(1, 0);
+}
+
+// Minimal mixed precision
+void
+mu_test_client__fp_round_all_floats_5(void)
+{
+  check_order_fp_encodings(1, 1);
+}
+
+// Balanced precision
+void
+mu_test_client__fp_round_all_floats_6(void)
+{
+  check_order_fp_encodings(10, 11);
+}
+
+void
+mu_test_client__fp_reject_large_small(void)
+{
+  reject_large_small();
+}
+
+void
+mu_test_client__fp_reject_nan_inf(void)
+{
+  reject_nan_inf();
+}
+
+void
+mu_test_client__fp_float_radix(void)
+{
+  float_radix();
+}
+
+void
+mu_test_client__fp_long_double_size(void)
+{
+  float_radix();
+}
+
+void
+mu_test_client__fp_round_step_sample(void)
+{
+  int ibits = 4;
+  int fbits = 17;
+  test_client_encode_decode_eps_steps(1, ibits, fbits, 15, 1, 0);
+}
+
+void
+mu_test_client__fp_round_and_aggregate_step_sample(void)
+{
+  int ibits = 4;
+  int fbits = 17;
+  test_client_encode_decode_eps_steps(10, ibits, fbits, 15, 1, 0);
+}
+
+void
+mu_test_client__fp_round_and_step_min(void)
+{
+  int ibits = 1;
+  int fbits = 1;
+  test_client_encode_decode_eps_steps(1, ibits, fbits, 4, 1, 5);
+}
+
+void
+mu_test_client__fp_round_and_aggregate_step_min(void)
+{
+  int ibits = 1;
+  int fbits = 1;
+  test_client_encode_decode_eps_steps(10, ibits, fbits, 4, 1, 5);
+}
+
+void
+mu_test_client__fp_round_and_aggregate_max_int(void)
+{
+  // Aggregate single entry submissions with maximal integer part
+  int ibits = 21;
+  int fbits = 0;
+  test_client_encode_decode_eps_steps(20, ibits, fbits, 1, 1, 2);
+}
+
+void
+mu_test_client__fp_round_and_aggregate_max_frac(void)
+{
+  // Aggregate single entry submissions with maximal fractional part
+  int ibits = 0;
+  int fbits = 21;
+  test_client_encode_decode_eps_steps(20, ibits, fbits, 1, 1, 2);
+}
+
+void
+mu_test_client__fp_round_and_aggregate_mixed_pos(void)
+{
+  // Aggregate single entry submissions with mixed precision and
+  // maximal positive values
+  int ibits = 10;
+  int fbits = 11;
+  test_client_encode_decode_eps_steps(2, ibits, fbits, 1, 1, 2);
+}
+
+void
+mu_test_client__fp_round_and_aggregate_mixed_neg(void)
+{
+  // Aggregate single entry submissions with mixed precision and
+  // maximal negative values
+  int ibits = 10;
+  int fbits = 11;
+  test_client_encode_decode_eps_steps(100, ibits, fbits, 1, 1, 3);
+}
+
+void
+mu_test_client__fp_exceed_FBITS_MAX(void)
+{
+  // Exceed FPBITS_MAX
+  int ibits = 11;
+  int fbits = 11;
+  test_client_encode_decode_eps_steps(1, ibits, fbits, 15, 0, 0);
+}
+
+void
+mu_test_client__fp_bits_too_low(void)
+{
+  // Exceed FPBITS_MAX
+  int ibits = 0;
+  int fbits = 0;
+  test_client_encode_decode_eps_steps(1, ibits, fbits, 15, 0, 0);
+}
+
+void
+mu_test_client__fp_mismatch(void)
+{
+  // Mismatch of FP format on client (correct) and server (ibits + 1)
+  int ibits = 10;
+  int fbits = 11;
+  test_client_encode_decode_eps_steps(1, ibits, fbits, 15, 1, 1);
+}
+
+// Move this to float_to_long
+void
+mu_test_client__fp_float_too_large1(void)
+{
+  // Pass a positive float x that is too large
+  int ibits = 10;
+  int fbits = 11;
+  test_client_encode_decode_eps_steps(1, ibits, fbits, 15, 1, 2);
+}
+
+// Move this to float_to_long
+void
+mu_test_client__fp_float_too_large2(void)
+{
+  // Pass a negative float that is too large
+  int ibits = 10;
+  int fbits = 11;
+  test_client_encode_decode_eps_steps(1, ibits, fbits, 15, 1, 3);
 }


### PR DESCRIPTION
Here is the first approach for a fixed point encoding (#106).

A couple of questions sorted by importance:
- What is the convention on bounds checks? Do we do them everytime or only in external functions? 

- The test suite right now is very exhaustive (e.g. encoding gets tested for all single precision floats). If these take too long, I can come up with a viable subset/sampling.

- Should I only add the methods to mprio.h or also client.h and server.h? (Did not do the latter with the uint circuit.)

- How should I call the convenience functions? Is PrioConfig_FP okay? I could also move them to fixed_point.h and prefix them with PrioFP for example.

Since this is another large PR, I'm happy about any suggestions to improve it.
